### PR TITLE
fix(mlgoo): preserve progress after rework resubmission

### DIFF
--- a/apps/api/app/schemas/mlgoo.py
+++ b/apps/api/app/schemas/mlgoo.py
@@ -310,6 +310,8 @@ class AssessorProgressItem(BaseModel):
     assessor_id: int | None
     assessor_name: str | None
     status: str  # pending, in_progress, reviewed, sent_for_rework
+    reviewed_indicators: int = Field(default=0, ge=0)
+    total_indicators: int = Field(default=0, ge=0)
     progress_percent: int = Field(ge=0, le=100)
     label: str
 

--- a/apps/api/app/services/assessor_service.py
+++ b/apps/api/app/services/assessor_service.py
@@ -410,7 +410,7 @@ class AssessorService:
                                     k.startswith("assessor_val_") for k in r.response_data.keys()
                                 )
                                 and r.updated_at
-                                and r.updated_at >= resubmit_timestamp
+                                and r.updated_at > resubmit_timestamp
                             )
                             re_review_progress = round(
                                 (re_reviewed_count / total_count * 100) if total_count > 0 else 0
@@ -428,7 +428,7 @@ class AssessorService:
                         for r in area_responses
                         if not r.requires_rework
                         and r.updated_at
-                        and r.updated_at >= a.calibration_submitted_at
+                        and r.updated_at > a.calibration_submitted_at
                         and (
                             r.validation_status is not None
                             or r.flagged_for_calibration

--- a/apps/api/app/services/mlgoo_service.py
+++ b/apps/api/app/services/mlgoo_service.py
@@ -207,7 +207,14 @@ class MLGOOService:
                 assessor_reviewed_indicators = total_indicators
                 assessor_progress_percent = 100
                 assessors_completed_count += 1
-            elif raw_area_status in {"submitted", "in_review", "rework"}:
+            elif raw_area_status == "rework":
+                assessor_status = "sent_for_rework"
+                assessor_progress_percent = (
+                    round((assessor_reviewed_indicators / total_indicators) * 100)
+                    if total_indicators > 0
+                    else 0
+                )
+            elif raw_area_status in {"submitted", "in_review"}:
                 if assessor_reviewed_indicators == 0:
                     assessor_status = "pending" if raw_area_status == "submitted" else "in_progress"
                     assessor_progress_percent = 0
@@ -1421,15 +1428,23 @@ class MLGOOService:
                 area_payload = assessment.area_submission_status.get(
                     str(indicator.governance_area_id), {}
                 )
-                if isinstance(area_payload, dict) and area_payload.get("resubmitted_after_rework"):
-                    submitted_at_raw = area_payload.get("submitted_at")
-                    if isinstance(submitted_at_raw, str):
-                        try:
-                            area_rework_resubmitted_at = datetime.fromisoformat(
-                                submitted_at_raw.replace("Z", "+00:00")
-                            ).replace(tzinfo=None)
-                        except ValueError:
-                            area_rework_resubmitted_at = None
+                if isinstance(area_payload, dict):
+                    is_rework_resubmission = bool(
+                        area_payload.get("resubmitted_after_rework")
+                        or area_payload.get("is_resubmission")
+                        or assessment.rework_submitted_at
+                    )
+                    if is_rework_resubmission:
+                        submitted_at_raw = area_payload.get("submitted_at")
+                        if isinstance(submitted_at_raw, str):
+                            try:
+                                area_rework_resubmitted_at = datetime.fromisoformat(
+                                    submitted_at_raw.replace("Z", "+00:00")
+                                ).replace(tzinfo=None)
+                            except ValueError:
+                                area_rework_resubmitted_at = None
+                        elif assessment.rework_submitted_at:
+                            area_rework_resubmitted_at = assessment.rework_submitted_at
 
             assessor_reviewed = bool(
                 response_data

--- a/apps/api/app/services/mlgoo_service.py
+++ b/apps/api/app/services/mlgoo_service.py
@@ -166,8 +166,11 @@ class MLGOOService:
                 if indicator.get("assessor_reviewed") is True:
                     assessor_reviewed_indicators += 1
 
-                if indicator.get("validator_reviewed") is True:
+                validator_review_state = indicator.get("validator_reviewed")
+                if validator_review_state is True:
                     validated_indicators += 1
+                    continue
+                if validator_review_state is False:
                     continue
 
                 raw_status = indicator.get("validation_status")
@@ -204,20 +207,19 @@ class MLGOOService:
                 assessor_reviewed_indicators = total_indicators
                 assessor_progress_percent = 100
                 assessors_completed_count += 1
-            elif raw_area_status == "rework":
-                assessor_status = "sent_for_rework"
-                assessor_progress_percent = (
-                    round((assessor_reviewed_indicators / total_indicators) * 100)
-                    if total_indicators > 0
-                    else 0
-                )
-            elif raw_area_status == "in_review":
-                assessor_status = "in_progress"
-                assessor_progress_percent = (
-                    round((assessor_reviewed_indicators / total_indicators) * 100)
-                    if total_indicators > 0
-                    else 0
-                )
+            elif raw_area_status in {"submitted", "in_review", "rework"}:
+                if assessor_reviewed_indicators == 0:
+                    assessor_status = "pending" if raw_area_status == "submitted" else "in_progress"
+                    assessor_progress_percent = 0
+                elif assessor_reviewed_indicators < total_indicators:
+                    assessor_status = "in_progress"
+                    assessor_progress_percent = round(
+                        (assessor_reviewed_indicators / total_indicators) * 100
+                    )
+                else:
+                    assessor_status = "reviewed"
+                    assessor_progress_percent = 100
+                    assessors_completed_count += 1
             else:
                 assessor_status = "pending"
                 assessor_progress_percent = 0
@@ -238,6 +240,8 @@ class MLGOOService:
                         "assessor_id": assessor_id,
                         "assessor_name": assessor_name,
                         "status": assessor_status,
+                        "reviewed_indicators": assessor_reviewed_indicators,
+                        "total_indicators": total_indicators,
                         "progress_percent": assessor_progress_percent,
                         "label": assessor_label(assessor_status),
                     },
@@ -1433,29 +1437,46 @@ class MLGOOService:
             )
             validator_reviewed = bool(response and response.validation_status is not None)
 
-            # Rework/calibration indicators are not considered reviewed until re-reviewed after resubmission.
-            if response and response.requires_rework:
-                assessor_reviewed = False
-                validator_reviewed = False
-
-            if (
+            requires_assessor_rereview = bool(response and response.requires_rework)
+            requires_validator_rereview = bool(response and response.flagged_for_calibration)
+            requires_mlgoo_rereview = bool(
                 response
-                and assessor_reviewed
-                and area_rework_resubmitted_at
-                and (not response.updated_at or response.updated_at < area_rework_resubmitted_at)
-            ):
-                assessor_reviewed = False
+                and response.indicator_id in (assessment.mlgoo_recalibration_indicator_ids or [])
+            )
 
-            if (
-                response
-                and validator_reviewed
-                and assessment.calibration_submitted_at
-                and (
-                    not response.updated_at
-                    or response.updated_at < assessment.calibration_submitted_at
-                )
-            ):
-                validator_reviewed = False
+            if requires_assessor_rereview:
+                if area_rework_resubmitted_at:
+                    assessor_reviewed = bool(
+                        response
+                        and response.updated_at
+                        and response.updated_at > area_rework_resubmitted_at
+                        and response_data
+                        and any(key.startswith("assessor_val_") for key in response_data.keys())
+                    )
+                else:
+                    assessor_reviewed = False
+
+            if requires_validator_rereview:
+                if assessment.calibration_submitted_at:
+                    validator_reviewed = bool(
+                        response
+                        and response.updated_at
+                        and response.updated_at > assessment.calibration_submitted_at
+                        and response.validation_status is not None
+                    )
+                else:
+                    validator_reviewed = False
+
+            if requires_mlgoo_rereview:
+                if assessment.mlgoo_recalibration_submitted_at:
+                    validator_reviewed = bool(
+                        response
+                        and response.updated_at
+                        and response.updated_at > assessment.mlgoo_recalibration_submitted_at
+                        and response.validation_status is not None
+                    )
+                else:
+                    validator_reviewed = False
 
             # Count statuses (only for indicators with responses and validation status)
             if response and response.validation_status:

--- a/apps/api/tests/api/v1/test_blgu_dashboard_rework_progress.py
+++ b/apps/api/tests/api/v1/test_blgu_dashboard_rework_progress.py
@@ -9,6 +9,7 @@ from app.db.enums import AreaType, AssessmentStatus, UserRole
 from app.db.models.assessment import Assessment, AssessmentResponse, MOVFile
 from app.db.models.barangay import Barangay
 from app.db.models.governance_area import GovernanceArea, Indicator
+from app.db.models.system import AssessmentYear
 from app.db.models.user import User
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -71,8 +72,24 @@ def test_dashboard_only_marks_completed_flagged_indicators_as_addressed(
     db_session.flush()
 
     requested_at = datetime.now(UTC) - timedelta(days=2)
+    assessment_year = AssessmentYear(
+        year=2026,
+        assessment_period_start=requested_at - timedelta(days=90),
+        assessment_period_end=requested_at + timedelta(days=90),
+        phase1_deadline=requested_at - timedelta(days=1),
+        submission_window_days=60,
+        rework_window_days=5,
+        calibration_window_days=3,
+        default_unlock_grace_period_days=5,
+        is_active=True,
+        is_published=True,
+    )
+    db_session.add(assessment_year)
+    db_session.flush()
+
     assessment = Assessment(
         blgu_user_id=user.id,
+        assessment_year=assessment_year.year,
         status=AssessmentStatus.NEEDS_REWORK,
         rework_count=1,
         rework_requested_at=requested_at,

--- a/apps/api/tests/services/test_assessor_service_noop_validation.py
+++ b/apps/api/tests/services/test_assessor_service_noop_validation.py
@@ -348,6 +348,68 @@ def test_get_validator_queue_does_not_count_false_only_checklist_data_as_reviewe
     assert queue[0]["re_review_progress"] == 0
 
 
+def test_get_assessor_queue_re_review_progress_requires_update_after_area_resubmission(
+    db_session, mock_governance_area
+):
+    response = create_validation_context(db_session, mock_governance_area)
+
+    assessor = User(
+        email="strict-re-review-assessor@test.com",
+        name="Strict Re-review Assessor",
+        role=UserRole.ASSESSOR,
+        assessor_area_id=mock_governance_area.id,
+        hashed_password="hashed_password",
+        is_active=True,
+    )
+    db_session.add(assessor)
+    db_session.commit()
+    db_session.refresh(assessor)
+
+    resubmitted_at = datetime(2025, 2, 2, 9, 0, 0)
+    assessment = response.assessment
+    assessment.status = AssessmentStatus.SUBMITTED_FOR_REVIEW
+    assessment.submitted_at = datetime(2025, 2, 1, 9, 0, 0)
+    assessment.area_submission_status = {
+        str(mock_governance_area.id): {
+            "status": "submitted",
+            "submitted_at": resubmitted_at.isoformat(),
+            "resubmitted_after_rework": True,
+        }
+    }
+    response.response_data = {"assessor_val_item_1": True}
+    response.requires_rework = False
+    response.updated_at = resubmitted_at
+    db_session.add_all([assessment, response])
+    db_session.commit()
+
+    queue = assessor_service.get_assessor_queue(db_session, assessor, assessment_year=2025)
+
+    assert len(queue) == 1
+    assert queue[0]["re_review_progress"] == 0
+
+
+def test_get_validator_queue_re_review_progress_requires_update_after_calibration_submission(
+    db_session, mock_governance_area, validator_user
+):
+    response = create_validation_context(db_session, mock_governance_area)
+
+    calibration_submitted_at = datetime(2025, 2, 2, 9, 0, 0)
+    assessment = response.assessment
+    assessment.status = AssessmentStatus.AWAITING_FINAL_VALIDATION
+    assessment.submitted_at = datetime(2025, 2, 1, 9, 0, 0)
+    assessment.calibration_submitted_at = calibration_submitted_at
+    response.validation_status = ValidationStatus.PASS
+    response.requires_rework = False
+    response.updated_at = calibration_submitted_at
+    db_session.add_all([assessment, response])
+    db_session.commit()
+
+    queue = assessor_service.get_assessor_queue(db_session, validator_user, assessment_year=2025)
+
+    assert len(queue) == 1
+    assert queue[0]["re_review_progress"] == 0
+
+
 def test_get_validator_queue_phase_gating_excludes_submitted_but_keeps_validation_and_calibration_rework(
     db_session, mock_governance_area, validator_user
 ):

--- a/apps/api/tests/services/test_mlgoo_service.py
+++ b/apps/api/tests/services/test_mlgoo_service.py
@@ -443,3 +443,100 @@ def test_get_assessment_details_keeps_cumulative_assessor_progress_after_rework_
     assert area_progress["assessor"]["total_indicators"] == 9
     assert area_progress["assessor"]["progress_percent"] == 89
     assert area_progress["assessor"]["status"] == "in_progress"
+
+
+def test_get_assessment_details_keeps_mlgoo_recalibration_target_pending_until_later_validation(
+    db_session,
+    mlgoo_user: User,
+    mock_blgu_user: User,
+    active_assessment_year: AssessmentYear,
+    mock_governance_area,
+):
+    from app.db.enums import ValidationStatus
+
+    parent = Indicator(
+        name="Recalibration Parent",
+        indicator_code="R",
+        governance_area_id=mock_governance_area.id,
+        sort_order=0,
+        description="Parent grouping",
+    )
+    db_session.add(parent)
+    db_session.flush()
+
+    reviewed_indicator = Indicator(
+        name="Reviewed Indicator",
+        indicator_code="1.1",
+        governance_area_id=mock_governance_area.id,
+        parent_id=parent.id,
+        sort_order=1,
+        description="Reviewed indicator",
+    )
+    recalibration_indicator = Indicator(
+        name="Recalibration Indicator",
+        indicator_code="1.2",
+        governance_area_id=mock_governance_area.id,
+        parent_id=parent.id,
+        sort_order=2,
+        description="Recalibration indicator",
+    )
+    db_session.add_all([reviewed_indicator, recalibration_indicator])
+    db_session.flush()
+
+    recalibration_submitted_at = datetime(2026, 4, 11, 9, 0, 0)
+    assessment = Assessment(
+        blgu_user_id=mock_blgu_user.id,
+        assessment_year=active_assessment_year.year,
+        status=AssessmentStatus.AWAITING_MLGOO_APPROVAL,
+        is_mlgoo_recalibration=True,
+        mlgoo_recalibration_indicator_ids=[recalibration_indicator.id],
+        mlgoo_recalibration_requested_at=datetime(2026, 4, 10, 8, 0, 0),
+        mlgoo_recalibration_submitted_at=recalibration_submitted_at,
+    )
+    db_session.add(assessment)
+    db_session.flush()
+
+    db_session.add_all(
+        [
+            AssessmentResponse(
+                assessment_id=assessment.id,
+                indicator_id=reviewed_indicator.id,
+                response_data={"assessor_val_status": "complete"},
+                is_completed=True,
+                validation_status=ValidationStatus.PASS,
+                updated_at=recalibration_submitted_at - timedelta(hours=2),
+            ),
+            AssessmentResponse(
+                assessment_id=assessment.id,
+                indicator_id=recalibration_indicator.id,
+                response_data={"assessor_val_status": "complete"},
+                is_completed=True,
+                validation_status=ValidationStatus.PASS,
+                updated_at=recalibration_submitted_at,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    details = mlgoo_service.get_assessment_details(
+        db=db_session,
+        assessment_id=assessment.id,
+        mlgoo_user=mlgoo_user,
+    )
+
+    [area_progress] = [
+        area
+        for area in details["assessment_progress"]["governance_areas"]
+        if area["governance_area_id"] == mock_governance_area.id
+    ]
+    [target_indicator] = [
+        indicator
+        for area in details["governance_areas"]
+        for indicator in area["indicators"]
+        if indicator["indicator_id"] == recalibration_indicator.id
+    ]
+
+    assert area_progress["validator"]["reviewed_indicators"] == 1
+    assert area_progress["validator"]["total_indicators"] == 2
+    assert area_progress["validator"]["progress_percent"] == 50
+    assert target_indicator["validator_reviewed"] is False

--- a/apps/api/tests/services/test_mlgoo_service.py
+++ b/apps/api/tests/services/test_mlgoo_service.py
@@ -445,6 +445,170 @@ def test_get_assessment_details_keeps_cumulative_assessor_progress_after_rework_
     assert area_progress["assessor"]["status"] == "in_progress"
 
 
+def test_get_assessment_details_preserves_sent_for_rework_status_with_counted_progress(
+    db_session,
+    mlgoo_user: User,
+    mock_blgu_user: User,
+    active_assessment_year: AssessmentYear,
+    mock_governance_area,
+):
+    from app.db.enums import ValidationStatus
+
+    parent = Indicator(
+        name="Rework Parent",
+        indicator_code="RW",
+        governance_area_id=mock_governance_area.id,
+        sort_order=0,
+        description="Parent grouping",
+    )
+    db_session.add(parent)
+    db_session.flush()
+
+    reviewed_indicator = Indicator(
+        name="Reviewed Indicator",
+        indicator_code="1.1",
+        governance_area_id=mock_governance_area.id,
+        parent_id=parent.id,
+        sort_order=1,
+        description="Reviewed indicator",
+    )
+    rework_indicator = Indicator(
+        name="Rework Indicator",
+        indicator_code="1.2",
+        governance_area_id=mock_governance_area.id,
+        parent_id=parent.id,
+        sort_order=2,
+        description="Rework indicator",
+    )
+    db_session.add_all([reviewed_indicator, rework_indicator])
+    db_session.flush()
+
+    assessment = Assessment(
+        blgu_user_id=mock_blgu_user.id,
+        assessment_year=active_assessment_year.year,
+        status=AssessmentStatus.SUBMITTED_FOR_REVIEW,
+        rework_count=1,
+        area_submission_status={str(mock_governance_area.id): {"status": "rework"}},
+        area_assessor_approved={str(mock_governance_area.id): False},
+    )
+    db_session.add(assessment)
+    db_session.flush()
+
+    db_session.add_all(
+        [
+            AssessmentResponse(
+                assessment_id=assessment.id,
+                indicator_id=reviewed_indicator.id,
+                response_data={"assessor_val_status": "complete"},
+                is_completed=True,
+                validation_status=ValidationStatus.PASS,
+                updated_at=datetime(2026, 4, 10, 8, 0, 0),
+            ),
+            AssessmentResponse(
+                assessment_id=assessment.id,
+                indicator_id=rework_indicator.id,
+                response_data={"assessor_val_status": "complete"},
+                is_completed=False,
+                requires_rework=True,
+                updated_at=datetime(2026, 4, 10, 8, 0, 0),
+            ),
+        ]
+    )
+    db_session.commit()
+
+    details = mlgoo_service.get_assessment_details(
+        db=db_session,
+        assessment_id=assessment.id,
+        mlgoo_user=mlgoo_user,
+    )
+
+    [area_progress] = [
+        area
+        for area in details["assessment_progress"]["governance_areas"]
+        if area["governance_area_id"] == mock_governance_area.id
+    ]
+
+    assert area_progress["assessor"]["status"] == "sent_for_rework"
+    assert area_progress["assessor"]["reviewed_indicators"] == 1
+    assert area_progress["assessor"]["total_indicators"] == 2
+    assert area_progress["assessor"]["progress_percent"] == 50
+
+
+def test_get_assessment_details_supports_legacy_rework_resubmission_flag(
+    db_session,
+    mlgoo_user: User,
+    mock_blgu_user: User,
+    active_assessment_year: AssessmentYear,
+    mock_governance_area,
+):
+    parent = Indicator(
+        name="Legacy Parent",
+        indicator_code="LG",
+        governance_area_id=mock_governance_area.id,
+        sort_order=0,
+        description="Parent grouping",
+    )
+    db_session.add(parent)
+    db_session.flush()
+
+    indicator = Indicator(
+        name="Legacy Rework Indicator",
+        indicator_code="1.1",
+        governance_area_id=mock_governance_area.id,
+        parent_id=parent.id,
+        sort_order=1,
+        description="Legacy rework indicator",
+    )
+    db_session.add(indicator)
+    db_session.flush()
+
+    resubmitted_at = datetime(2026, 4, 11, 9, 0, 0)
+    assessment = Assessment(
+        blgu_user_id=mock_blgu_user.id,
+        assessment_year=active_assessment_year.year,
+        status=AssessmentStatus.SUBMITTED_FOR_REVIEW,
+        rework_count=1,
+        area_submission_status={
+            str(mock_governance_area.id): {
+                "status": "submitted",
+                "submitted_at": resubmitted_at.isoformat(),
+                "is_resubmission": True,
+            }
+        },
+        area_assessor_approved={str(mock_governance_area.id): False},
+    )
+    db_session.add(assessment)
+    db_session.flush()
+
+    db_session.add(
+        AssessmentResponse(
+            assessment_id=assessment.id,
+            indicator_id=indicator.id,
+            response_data={"assessor_val_status": "complete"},
+            is_completed=True,
+            requires_rework=True,
+            updated_at=resubmitted_at + timedelta(minutes=1),
+        )
+    )
+    db_session.commit()
+
+    details = mlgoo_service.get_assessment_details(
+        db=db_session,
+        assessment_id=assessment.id,
+        mlgoo_user=mlgoo_user,
+    )
+
+    [area_progress] = [
+        area
+        for area in details["assessment_progress"]["governance_areas"]
+        if area["governance_area_id"] == mock_governance_area.id
+    ]
+
+    assert area_progress["assessor"]["reviewed_indicators"] == 1
+    assert area_progress["assessor"]["progress_percent"] == 100
+    assert area_progress["assessor"]["status"] == "reviewed"
+
+
 def test_get_assessment_details_keeps_mlgoo_recalibration_target_pending_until_later_validation(
     db_session,
     mlgoo_user: User,

--- a/apps/api/tests/services/test_mlgoo_service.py
+++ b/apps/api/tests/services/test_mlgoo_service.py
@@ -343,3 +343,103 @@ def test_get_assessment_details_keeps_all_mov_files_for_indicator_with_upload_or
         MOV_UPLOAD_ORIGIN_BLGU,
         MOV_UPLOAD_ORIGIN_VALIDATOR,
     ]
+
+
+def test_get_assessment_details_keeps_cumulative_assessor_progress_after_rework_resubmission(
+    db_session,
+    mlgoo_user: User,
+    mock_blgu_user: User,
+    active_assessment_year: AssessmentYear,
+    mock_governance_area,
+):
+    from app.db.enums import UserRole, ValidationStatus
+
+    assessor = User(
+        email="progress-assessor@test.gov.ph",
+        name="Progress Assessor",
+        hashed_password="test",
+        role=UserRole.ASSESSOR,
+        assessor_area_id=mock_governance_area.id,
+        is_active=True,
+    )
+    db_session.add(assessor)
+    db_session.flush()
+
+    parent = Indicator(
+        name="Progress Parent",
+        indicator_code="P",
+        governance_area_id=mock_governance_area.id,
+        sort_order=0,
+        description="Parent grouping",
+    )
+    db_session.add(parent)
+    db_session.flush()
+
+    indicators = []
+    for index in range(1, 10):
+        indicator = Indicator(
+            name=f"Progress Indicator {index}",
+            indicator_code=f"1.{index}",
+            governance_area_id=mock_governance_area.id,
+            parent_id=parent.id,
+            sort_order=index,
+            description=f"Indicator {index}",
+        )
+        db_session.add(indicator)
+        indicators.append(indicator)
+    db_session.flush()
+
+    rework_requested_at = datetime(2026, 4, 10, 8, 0, 0)
+    resubmitted_at = datetime(2026, 4, 11, 9, 0, 0)
+    assessment = Assessment(
+        blgu_user_id=mock_blgu_user.id,
+        assessment_year=active_assessment_year.year,
+        status=AssessmentStatus.SUBMITTED_FOR_REVIEW,
+        rework_count=1,
+        rework_requested_at=rework_requested_at,
+        area_submission_status={
+            str(mock_governance_area.id): {
+                "status": "submitted",
+                "assessor_id": assessor.id,
+                "submitted_at": resubmitted_at.isoformat(),
+                "resubmitted_after_rework": True,
+            }
+        },
+        area_assessor_approved={str(mock_governance_area.id): False},
+    )
+    db_session.add(assessment)
+    db_session.flush()
+
+    for index, indicator in enumerate(indicators, start=1):
+        is_rework_indicator = index == 9
+        reviewed_at = resubmitted_at - timedelta(hours=2)
+        response = AssessmentResponse(
+            assessment_id=assessment.id,
+            indicator_id=indicator.id,
+            response_data={"assessor_val_status": "complete"},
+            is_completed=not is_rework_indicator,
+            requires_rework=is_rework_indicator,
+            validation_status=ValidationStatus.PASS if not is_rework_indicator else None,
+            updated_at=reviewed_at,
+        )
+        db_session.add(response)
+
+    db_session.commit()
+
+    details = mlgoo_service.get_assessment_details(
+        db=db_session,
+        assessment_id=assessment.id,
+        mlgoo_user=mlgoo_user,
+    )
+
+    [area_progress] = [
+        area
+        for area in details["assessment_progress"]["governance_areas"]
+        if area["governance_area_id"] == mock_governance_area.id
+    ]
+
+    assert area_progress["total_indicators"] == 9
+    assert area_progress["assessor"]["reviewed_indicators"] == 8
+    assert area_progress["assessor"]["total_indicators"] == 9
+    assert area_progress["assessor"]["progress_percent"] == 89
+    assert area_progress["assessor"]["status"] == "in_progress"

--- a/apps/web/src/app/(app)/mlgoo/submissions/[id]/page.tsx
+++ b/apps/web/src/app/(app)/mlgoo/submissions/[id]/page.tsx
@@ -276,6 +276,8 @@ interface AssessorProgressData {
   assessor_id?: number | null;
   assessor_name?: string | null;
   status?: string;
+  reviewed_indicators?: number;
+  total_indicators?: number;
   progress_percent?: number;
   label?: string;
 }
@@ -2412,7 +2414,8 @@ export default function SubmissionDetailsPage() {
                     const assessorName =
                       areaProgress.assessor.assessor_name || "Unassigned Assessor";
                     const validatorDisplayName = "Validators";
-                    const assessorTotalIndicators = areaProgress.total_indicators || 0;
+                    const assessorTotalIndicators =
+                      areaProgress.assessor.total_indicators || areaProgress.total_indicators || 0;
                     const fallbackAssessorReviewedIndicators = [
                       "reviewed",
                       "sent_for_rework",
@@ -2445,10 +2448,13 @@ export default function SubmissionDetailsPage() {
                         sensitivity: "base",
                       })
                     );
+                    const apiAssessorReviewedIndicators = areaProgress.assessor.reviewed_indicators;
                     const assessorReviewedIndicators =
-                      sortedIndicators.length > 0
-                        ? sortedIndicators.filter(isAssessorIndicatorCompleted).length
-                        : fallbackAssessorReviewedIndicators;
+                      typeof apiAssessorReviewedIndicators === "number"
+                        ? apiAssessorReviewedIndicators
+                        : sortedIndicators.length > 0
+                          ? sortedIndicators.filter(isAssessorIndicatorCompleted).length
+                          : fallbackAssessorReviewedIndicators;
                     const validatorReviewedIndicators =
                       sortedIndicators.length > 0
                         ? sortedIndicators.filter(isValidatorIndicatorCompleted).length

--- a/packages/shared/src/generated/schemas/assessor/index.ts
+++ b/packages/shared/src/generated/schemas/assessor/index.ts
@@ -66,6 +66,10 @@ export interface AssessorProgressItem {
   assessor_id: AssessorProgressItemAssessorId;
   assessor_name: AssessorProgressItemAssessorName;
   status: string;
+  /** @minimum 0 */
+  reviewed_indicators?: number;
+  /** @minimum 0 */
+  total_indicators?: number;
   /**
    * @minimum 0
    * @maximum 100


### PR DESCRIPTION
## Summary
- Preserve cumulative MLGOO assessor progress after BLGU resubmits only flagged indicators
- Add assessor reviewed/total counts to the MLGOO progress payload and generated shared types
- Use strict post-resubmission timestamp checks for rework, calibration, and MLGOO recalibration flows
- Update MLGOO progress UI to prefer backend assessor counts

## Test Plan
- [x] cd apps/api && uv run pytest tests/services/test_mlgoo_service.py tests/services/test_assessor_service_noop_validation.py tests/api/v1/test_blgu_dashboard_rework_progress.py -q
- [x] cd apps/api && uv run ruff check app/services/mlgoo_service.py app/services/assessor_service.py tests/services/test_mlgoo_service.py tests/services/test_assessor_service_noop_validation.py
- [x] pnpm generate-types
- [x] pnpm --filter @sinag/shared type-check

## Notes
- Full web/API type-check and full API test suite have unrelated existing failures; targeted SNG-30 validation passes.
- Untracked local docs files are intentionally not included.