### PR TITLE
fix(validator): allow MOV upload and delete during validation phase

### DIFF
--- a/apps/api/app/api/v1/movs.py
+++ b/apps/api/app/api/v1/movs.py
@@ -118,10 +118,15 @@ def upload_mov_file(
         upload_origin = MOV_UPLOAD_ORIGIN_BLGU
     elif current_user.role == UserRole.VALIDATOR:
         assert assessment is not None
-        if assessment.status != AssessmentStatus.SUBMITTED:
+        if assessment.status not in (
+            AssessmentStatus.AWAITING_FINAL_VALIDATION,
+            AssessmentStatus.REWORK,
+        ) or (
+            assessment.status == AssessmentStatus.REWORK and not assessment.is_calibration_rework
+        ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="Validators can only upload MOV files for submitted assessments",
+                detail="Validators can only upload MOV files for assessments awaiting final validation",
             )
         response = (
             db.query(AssessmentResponse)

--- a/apps/api/app/services/storage_service.py
+++ b/apps/api/app/services/storage_service.py
@@ -703,11 +703,17 @@ class StorageService:
             if mov_file.upload_origin != MOV_UPLOAD_ORIGIN_VALIDATOR:
                 return False, "Validators can only delete validator-uploaded files"
 
-            if assessment.status != AssessmentStatus.SUBMITTED:
+            if assessment.status not in (
+                AssessmentStatus.AWAITING_FINAL_VALIDATION,
+                AssessmentStatus.REWORK,
+            ) or (
+                assessment.status == AssessmentStatus.REWORK
+                and not assessment.is_calibration_rework
+            ):
                 return (
                     False,
                     f"Cannot delete validator-uploaded files from {assessment.status} assessments. "
-                    f"Deletion is only allowed while the assessment is Submitted.",
+                    f"Deletion is only allowed for assessments awaiting final validation.",
                 )
 
             return True, None


### PR DESCRIPTION
This PR updates the authorization logic for the MOV upload and delete endpoints. 

### Problem:
Validators were receiving 'Access denied' errors when trying to upload files on behalf of barangays or delete their own evidence during Phase 2 (Table Validation). This was because the backend was strictly checking for 'SUBMITTED' status (Phase 1).

### Solution:
Updated  and  to allow  actions when the assessment is in  or during a calibration  cycle.

Verified by confirming the logic in both the API layer and the storage service layer.