### PR TITLE
fix(web): show warning icons for flagged indicators in validator sidebar

### DIFF
--- a/apps/web/src/components/features/assessments/tree-navigation/AssessmentTreeNode.tsx
+++ b/apps/web/src/components/features/assessments/tree-navigation/AssessmentTreeNode.tsx
@@ -40,6 +40,7 @@ interface AssessmentTreeNodeProps {
   // Per-area rework/calibration tracking
   remainingAttempts?: { reworkLeft: boolean; calibrationLeft: boolean };
   isAssessmentLockedForBlgu?: boolean;
+  movAttentionVariant?: "warning" | "danger";
 }
 
 export function AssessmentTreeNode({
@@ -58,6 +59,7 @@ export function AssessmentTreeNode({
   onAreaSubmitSuccess,
   remainingAttempts,
   isAssessmentLockedForBlgu = false,
+  movAttentionVariant = "warning",
 }: AssessmentTreeNodeProps) {
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -160,19 +162,47 @@ export function AssessmentTreeNode({
 
     // Show yellow warning for indicators with MOV notes or flagged files
     if (indicator.hasMovNotes) {
-      // If also completed, show warning triangle (notes take visual priority)
-      return <AlertTriangle className="h-3.5 w-3.5 text-yellow-500" aria-hidden="true" />;
+      // If also completed, MOV attention takes visual priority.
+      if (movAttentionVariant === "danger") {
+        return (
+          <AlertCircle
+            className="h-3.5 w-3.5 text-red-500"
+            aria-label="Indicator needs attention"
+          />
+        );
+      }
+
+      return (
+        <AlertTriangle
+          className="h-3.5 w-3.5 text-yellow-500"
+          aria-label="Indicator has MOV notes"
+        />
+      );
     }
 
     switch (indicator.status) {
       case "completed":
-        return <CheckCircle className="h-3.5 w-3.5 text-green-500" aria-hidden="true" />;
+        return (
+          <CheckCircle className="h-3.5 w-3.5 text-green-500" aria-label="Indicator complete" />
+        );
       case "flagged_for_rework":
-        return <AlertTriangle className="h-3.5 w-3.5 text-orange-500" aria-hidden="true" />;
+        return (
+          <AlertTriangle
+            className="h-3.5 w-3.5 text-orange-500"
+            aria-label="Indicator flagged for rework"
+          />
+        );
       case "needs_rework":
-        return <AlertCircle className="h-3.5 w-3.5 text-orange-500" aria-hidden="true" />;
+        return (
+          <AlertCircle
+            className="h-3.5 w-3.5 text-orange-500"
+            aria-label="Indicator needs rework"
+          />
+        );
       default:
-        return <Circle className="h-3.5 w-3.5 text-[var(--border)]" aria-hidden="true" />;
+        return (
+          <Circle className="h-3.5 w-3.5 text-[var(--border)]" aria-label="Indicator not started" />
+        );
     }
   };
 

--- a/apps/web/src/components/features/assessments/tree-navigation/TreeNavigator.tsx
+++ b/apps/web/src/components/features/assessments/tree-navigation/TreeNavigator.tsx
@@ -33,6 +33,7 @@ interface TreeNavigatorProps {
   onAreaSubmitSuccess?: () => void;
   areaAssessorStatus?: AreaAssessorStatusItem[];
   isAssessmentLockedForBlgu?: boolean;
+  movAttentionVariant?: "warning" | "danger";
 }
 
 export function TreeNavigator({
@@ -43,6 +44,7 @@ export function TreeNavigator({
   onAreaSubmitSuccess,
   areaAssessorStatus,
   isAssessmentLockedForBlgu = false,
+  movAttentionVariant = "warning",
 }: TreeNavigatorProps) {
   // Load expanded state from sessionStorage or auto-expand first incomplete
   const [expandedAreas, setExpandedAreas] = useState<Set<string>>(() => {
@@ -119,6 +121,7 @@ export function TreeNavigator({
             isActive={selectedIndicatorId === indicator.id}
             onClick={() => handleIndicatorClick(indicator.id)}
             level={level}
+            movAttentionVariant={movAttentionVariant}
           />
         </div>
       );

--- a/apps/web/src/components/features/assessments/tree-navigation/__tests__/AssessmentTreeNode.test.tsx
+++ b/apps/web/src/components/features/assessments/tree-navigation/__tests__/AssessmentTreeNode.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AssessmentTreeNode } from "../AssessmentTreeNode";
+import type { Indicator } from "@/types/assessment";
+
+function makeIndicator(overrides: Partial<Indicator> = {}): Indicator {
+  return {
+    id: "201",
+    code: "1.3.1",
+    name: "Presence of a Barangay Appropriation Ordinance",
+    description: "",
+    technicalNotes: "",
+    governanceAreaId: "1",
+    status: "completed",
+    movFiles: [],
+    formSchema: { properties: {} },
+    ...overrides,
+  };
+}
+
+describe("AssessmentTreeNode", () => {
+  it("keeps the default yellow MOV attention icon for shared non-validator trees", () => {
+    render(
+      <AssessmentTreeNode
+        type="indicator"
+        item={makeIndicator({ hasMovNotes: true, status: "completed" })}
+      />
+    );
+
+    const icon = screen.getByLabelText("Indicator has MOV notes");
+    expect(icon).toHaveClass("text-yellow-500");
+    expect(screen.queryByLabelText("Indicator complete")).not.toBeInTheDocument();
+  });
+
+  it("shows a red warning icon before the completed icon for validator MOV attention", () => {
+    render(
+      <AssessmentTreeNode
+        type="indicator"
+        item={makeIndicator({ hasMovNotes: true, status: "completed" })}
+        movAttentionVariant="danger"
+      />
+    );
+
+    const icon = screen.getByLabelText("Indicator needs attention");
+    expect(icon).toHaveClass("text-red-500");
+    expect(screen.queryByLabelText("Indicator complete")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
+++ b/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
@@ -260,6 +260,8 @@ interface MiddleMovFilesPanelProps {
   onReworkFlagSaved?: (responseId: number, movFileId: number, flagged: boolean) => void;
   /** Callback when validator toggles calibration flag (validators only) */
   onCalibrationFlagChange?: (responseId: number, flagged: boolean) => void;
+  /** Callback while validator MOV note/flag edits make one open file need attention */
+  onMovAttentionChange?: (responseId: number, movFileId: number, hasAttention: boolean) => void;
 }
 
 type AnyRecord = Record<string, any>;
@@ -431,6 +433,7 @@ export function MiddleMovFilesPanel({
   onAnnotationDeleted,
   onReworkFlagSaved,
   onCalibrationFlagChange,
+  onMovAttentionChange,
 }: MiddleMovFilesPanelProps) {
   const { user } = useAuthStore();
   const isValidator = user?.role === "VALIDATOR";
@@ -682,6 +685,20 @@ export function MiddleMovFilesPanel({
       setFeedbackDirty(false);
     }
   }, [isAnnotating]);
+
+  React.useEffect(() => {
+    if (!isValidator || !expandedId || !selectedFile?.id || !onMovAttentionChange) return;
+
+    const currentResponseId = expandedId;
+    const currentMovFileId = selectedFile.id;
+    const hasAttention = movFlagged || movNotes.trim().length > 0;
+
+    onMovAttentionChange(currentResponseId, currentMovFileId, hasAttention);
+
+    return () => {
+      onMovAttentionChange(currentResponseId, currentMovFileId, false);
+    };
+  }, [movNotes, movFlagged, isValidator, expandedId, selectedFile?.id, onMovAttentionChange]);
 
   // Auto-toggle flag when notes are added
   const handleNotesChange = (value: string) => {

--- a/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
+++ b/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
@@ -305,6 +305,62 @@ function sortFilesByUploadedAtDesc<T extends { uploaded_at?: string | null }>(fi
   });
 }
 
+function patchMovFeedbackInAssessmentCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  assessmentId: number,
+  movFileId: number,
+  feedback: AnyRecord
+) {
+  if (assessmentId <= 0) return;
+
+  const queryKey = getGetAssessorAssessmentsAssessmentIdQueryKey(assessmentId);
+
+  queryClient.setQueryData(queryKey, (current: unknown) => {
+    if (!current || typeof current !== "object") return current;
+
+    const root = current as AnyRecord;
+    const core = (root.assessment as AnyRecord | undefined) ?? root;
+    const responses = Array.isArray(core.responses) ? core.responses : null;
+    if (!responses) return current;
+
+    let didUpdateMov = false;
+    const nextResponses = responses.map((response: AnyRecord) => {
+      const movs = Array.isArray(response.movs) ? response.movs : null;
+      if (!movs) return response;
+
+      const nextMovs = movs.map((mov: AnyRecord) => {
+        if (Number(mov.id) !== movFileId) return mov;
+
+        didUpdateMov = true;
+        return {
+          ...mov,
+          assessor_notes:
+            feedback.assessor_notes !== undefined ? feedback.assessor_notes : mov.assessor_notes,
+          flagged_for_rework:
+            feedback.flagged_for_rework !== undefined
+              ? feedback.flagged_for_rework
+              : mov.flagged_for_rework,
+          validator_notes:
+            feedback.validator_notes !== undefined ? feedback.validator_notes : mov.validator_notes,
+          flagged_for_calibration:
+            feedback.flagged_for_calibration !== undefined
+              ? feedback.flagged_for_calibration
+              : mov.flagged_for_calibration,
+        };
+      });
+
+      return didUpdateMov ? { ...response, movs: nextMovs } : response;
+    });
+
+    if (!didUpdateMov) return current;
+
+    const nextCore = { ...core, responses: nextResponses };
+    return root.assessment ? { ...root, assessment: nextCore } : nextCore;
+  });
+
+  void queryClient.invalidateQueries({ queryKey, refetchType: "active" });
+}
+
 function ReviewFileSection({
   title,
   files,
@@ -644,6 +700,12 @@ export function MiddleMovFilesPanel({
       onSuccess: (_data, variables) => {
         toast.success("Feedback saved");
         setFeedbackDirty(false);
+        patchMovFeedbackInAssessmentCache(
+          queryClient,
+          assessmentId,
+          variables.movFileId,
+          variables.data as AnyRecord
+        );
         const flaggedValue = isValidator
           ? (variables.data as AnyRecord).flagged_for_calibration
           : (variables.data as AnyRecord).flagged_for_rework;

--- a/apps/web/src/components/features/assessor/validation/__tests__/MiddleMovFilesPanel.test.tsx
+++ b/apps/web/src/components/features/assessor/validation/__tests__/MiddleMovFilesPanel.test.tsx
@@ -10,6 +10,7 @@ import { MiddleMovFilesPanel } from "../MiddleMovFilesPanel";
 
 const mockUploadMutate = vi.fn();
 const mockDeleteMutate = vi.fn();
+const mockPatchFeedbackMutate = vi.fn();
 let isUploadPending = false;
 
 vi.mock("@sinag/shared", () => ({
@@ -30,8 +31,11 @@ vi.mock("@sinag/shared", () => ({
     mutate: mockDeleteMutate,
     isPending: false,
   })),
-  usePatchAssessorMovsMovFileIdFeedback: vi.fn(() => ({
-    mutate: vi.fn(),
+  usePatchAssessorMovsMovFileIdFeedback: vi.fn((options: any) => ({
+    mutate: (variables: any) => {
+      mockPatchFeedbackMutate(variables);
+      options?.mutation?.onSuccess?.({}, variables);
+    },
     isPending: false,
   })),
 }));
@@ -115,13 +119,15 @@ vi.mock("@/components/features/movs/FileUpload", () => ({
   ),
 }));
 
-const wrap = (ui: React.ReactNode) => {
-  const client = new QueryClient({
+const createTestQueryClient = () =>
+  new QueryClient({
     defaultOptions: {
       queries: { retry: false },
       mutations: { retry: false },
     },
   });
+
+const wrap = (ui: React.ReactNode, client = createTestQueryClient()) => {
   return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
 };
 
@@ -212,6 +218,7 @@ describe("MiddleMovFilesPanel", () => {
     vi.clearAllMocks();
     mockUploadMutate.mockReset();
     mockDeleteMutate.mockReset();
+    mockPatchFeedbackMutate.mockReset();
     isUploadPending = false;
   });
 
@@ -432,6 +439,52 @@ describe("MiddleMovFilesPanel", () => {
     expect(
       screen.queryByRole("button", { name: /view barangay upload history/i })
     ).not.toBeInTheDocument();
+  });
+
+  it("patches cached assessment MOV feedback after validator feedback is saved", async () => {
+    const user = userEvent.setup();
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(useAuthStore).mockReturnValue({
+      user: { id: 42, role: "VALIDATOR" },
+    });
+    queryClient.setQueryData(["assessor-assessment", 1], assessment);
+
+    render(
+      wrap(<MiddleMovFilesPanel assessment={assessment as any} expandedId={101} />, queryClient)
+    );
+
+    await user.click(screen.getByRole("button", { name: /preview evidence\.png/i }));
+    await user.type(
+      screen.getByPlaceholderText(/describe the specific issue with this file/i),
+      "no signature"
+    );
+    await user.click(screen.getByRole("button", { name: /save feedback/i }));
+
+    expect(mockPatchFeedbackMutate).toHaveBeenCalledWith({
+      movFileId: 9,
+      data: {
+        assessor_notes: undefined,
+        flagged_for_rework: undefined,
+        validator_notes: "no signature",
+        flagged_for_calibration: true,
+      },
+    });
+    expect(queryClient.getQueryData<any>(["assessor-assessment", 1])).toMatchObject({
+      assessment: {
+        responses: [
+          {
+            movs: [
+              {
+                id: 9,
+                validator_notes: "no signature",
+                flagged_for_calibration: true,
+              },
+            ],
+          },
+        ],
+      },
+    });
   });
 
   it("lets validators remove only their own validator-uploaded files", async () => {

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -358,9 +358,11 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   // 3. Already has a validation status from database (PASS/FAIL/CONDITIONAL - e.g., after calibration), OR
   // 4. Validator has entered a comment/finding
   const isIndicatorReviewed = (responseId: number): boolean => {
+    const response = responses.find((r: AnyRecord) => r.id === responseId);
+
     return (
       hasChecklistItemsChecked(responseId) ||
-      calibrationFlags[responseId] === true ||
+      (response ? responseHasAttention(response) : calibrationFlags[responseId] === true) ||
       hasExistingValidationStatus(responseId) ||
       hasValidatorComment(responseId)
     );

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -324,6 +324,22 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     return !!(formData?.publicComment && formData.publicComment.trim().length > 0);
   };
 
+  const responseHasServerMovAttention = (response: AnyRecord): boolean => {
+    const movs = Array.isArray(response.movs) ? response.movs : [];
+
+    return movs.some((mov: AnyRecord) => {
+      const hasValidatorNotes = Boolean(
+        mov.validator_notes && String(mov.validator_notes).trim().length > 0
+      );
+
+      return hasValidatorNotes || mov.flagged_for_calibration === true;
+    });
+  };
+
+  const responseHasAttention = (response: AnyRecord): boolean => {
+    return responseHasServerMovAttention(response) || calibrationFlags[response.id] === true;
+  };
+
   // Helper: Check if an indicator is "reviewed"
   // An indicator is reviewed if:
   // 1. Has checklist items checked in current session, OR
@@ -369,6 +385,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
         name: indicator.name || "Unnamed Indicator",
         // For validators: Show completed if checklist items checked OR flagged for calibration
         status: isIndicatorReviewed(resp.id) ? "completed" : "not_started",
+        hasMovNotes: responseHasAttention(resp),
       });
 
       // Sort indicators by code after adding
@@ -1016,6 +1033,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                   assessment={transformedAssessment as any}
                   selectedIndicatorId={selectedIndicatorId}
                   onIndicatorSelect={handleIndicatorSelect}
+                  movAttentionVariant="danger"
                 />
               </div>
             )}
@@ -1071,6 +1089,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                   assessment={transformedAssessment as any}
                   selectedIndicatorId={selectedIndicatorId}
                   onIndicatorSelect={handleIndicatorSelect}
+                  movAttentionVariant="danger"
                 />
               </div>
             </div>
@@ -1163,6 +1182,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                   assessment={transformedAssessment as any}
                   selectedIndicatorId={selectedIndicatorId}
                   onIndicatorSelect={handleIndicatorSelect}
+                  movAttentionVariant="danger"
                 />
               </div>
             </div>

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -29,7 +29,7 @@ import { ChevronLeft, ClipboardCheck } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { MiddleMovFilesPanel } from "../assessor/validation/MiddleMovFilesPanel";
 
@@ -97,6 +97,9 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   const [checklistState, setChecklistState] = useState<Record<string, any>>({});
   // Store calibration flag state (which indicators are flagged for calibration)
   const [calibrationFlags, setCalibrationFlags] = useState<Record<number, boolean>>({});
+  const [movAttentionByResponse, setMovAttentionByResponse] = useState<
+    Record<number, Record<number, boolean>>
+  >({});
   const [draftSaveState, setDraftSaveState] = useState<DraftSaveState>("idle");
   const [completedAutosaveCount, setCompletedAutosaveCount] = useState(0);
   const [dirtyResponseIds, setDirtyResponseIds] = useState<number[]>([]);
@@ -337,7 +340,15 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   };
 
   const responseHasAttention = (response: AnyRecord): boolean => {
-    return responseHasServerMovAttention(response) || calibrationFlags[response.id] === true;
+    const localFileAttention = Object.values(movAttentionByResponse[response.id] ?? {}).some(
+      Boolean
+    );
+
+    return (
+      responseHasServerMovAttention(response) ||
+      localFileAttention ||
+      calibrationFlags[response.id] === true
+    );
   };
 
   // Helper: Check if an indicator is "reviewed"
@@ -898,6 +909,19 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     }, 0);
   };
 
+  const handleMovAttentionChange = useCallback(
+    (responseId: number, movFileId: number, hasAttention: boolean) => {
+      setMovAttentionByResponse((prev) => ({
+        ...prev,
+        [responseId]: {
+          ...(prev[responseId] ?? {}),
+          [movFileId]: hasAttention,
+        },
+      }));
+    },
+    []
+  );
+
   if (isLoading) {
     return (
       <div className="mx-auto max-w-7xl px-6 py-10 text-sm text-muted-foreground">
@@ -1058,6 +1082,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                       handleCalibrationFlagChange(responseId, false);
                     }
                   }}
+                  onMovAttentionChange={handleMovAttentionChange}
                 />
               </div>
             )}
@@ -1149,6 +1174,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                           handleCalibrationFlagChange(responseId, false);
                         }
                       }}
+                      onMovAttentionChange={handleMovAttentionChange}
                     />
                   </div>
                 )}
@@ -1208,6 +1234,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                     handleCalibrationFlagChange(responseId, false);
                   }
                 }}
+                onMovAttentionChange={handleMovAttentionChange}
               />
             </div>
 

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -82,7 +82,22 @@ vi.mock("../../assessor/validation/MiddleMovFilesPanel", () => ({
 }));
 
 vi.mock("@/components/features/assessments/tree-navigation", () => ({
-  TreeNavigator: () => <div data-testid="tree-nav" />,
+  TreeNavigator: ({ assessment }: any) => (
+    <div data-testid="tree-nav">
+      {assessment.governanceAreas.flatMap((area: any) =>
+        area.indicators.map((indicator: any) => (
+          <div
+            key={indicator.id}
+            data-testid={`tree-indicator-${indicator.id}`}
+            data-has-mov-notes={String(Boolean(indicator.hasMovNotes))}
+            data-status={indicator.status}
+          >
+            {indicator.code}
+          </div>
+        ))
+      )}
+    </div>
+  ),
 }));
 
 vi.mock("sonner", () => ({
@@ -125,7 +140,16 @@ function wrap(ui: React.ReactNode) {
   return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
 }
 
-function makeAssessment() {
+function expectSidebarAttention(responseId: number, hasAttention: boolean) {
+  const indicators = screen.getAllByTestId(`tree-indicator-${responseId}`);
+
+  expect(indicators.length).toBeGreaterThan(0);
+  indicators.forEach((indicator) => {
+    expect(indicator).toHaveAttribute("data-has-mov-notes", String(hasAttention));
+  });
+}
+
+function makeAssessment(responseOverrides: Record<string, any> = {}) {
   return {
     success: true,
     assessment_id: 1,
@@ -154,6 +178,7 @@ function makeAssessment() {
           feedback_comments: [],
           validation_status: "PASS",
           flagged_for_calibration: false,
+          ...responseOverrides,
         },
       ],
     },
@@ -289,5 +314,49 @@ describe("ValidatorValidationClient autosave", () => {
     }).not.toThrow();
 
     expect(screen.getByText(/loading assessment/i)).toBeInTheDocument();
+  });
+
+  it("marks a validator sidebar indicator as needing attention when a MOV has validator notes", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment({
+        movs: [
+          {
+            id: 1,
+            uploaded_at: "2024-01-01T00:00:00Z",
+            validator_notes: "no signature",
+            flagged_for_calibration: false,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    expectSidebarAttention(201, true);
+  });
+
+  it("marks a validator sidebar indicator as needing attention when a MOV is flagged for calibration", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment({
+        movs: [
+          {
+            id: 1,
+            uploaded_at: "2024-01-01T00:00:00Z",
+            validator_notes: "",
+            flagged_for_calibration: true,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    expectSidebarAttention(201, true);
   });
 });

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -347,6 +347,32 @@ describe("ValidatorValidationClient autosave", () => {
     expectSidebarAttention(201, true);
   });
 
+  it("counts a saved validator MOV note as reviewed even without a validation status", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment({
+        validation_status: null,
+        movs: [
+          {
+            id: 1,
+            uploaded_at: "2024-01-01T00:00:00Z",
+            validator_notes: "no signature",
+            flagged_for_calibration: false,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    screen.getAllByTestId("tree-indicator-201").forEach((indicator) => {
+      expect(indicator).toHaveAttribute("data-has-mov-notes", "true");
+      expect(indicator).toHaveAttribute("data-status", "completed");
+    });
+  });
+
   it("marks a validator sidebar indicator as needing attention when a MOV is flagged for calibration", () => {
     mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
       data: makeAssessment({

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -78,7 +78,16 @@ vi.mock("next/dynamic", () => ({
 }));
 
 vi.mock("../../assessor/validation/MiddleMovFilesPanel", () => ({
-  MiddleMovFilesPanel: () => <div data-testid="mov-panel" />,
+  MiddleMovFilesPanel: (props: any) => (
+    <div data-testid="mov-panel">
+      <button onClick={() => props.onMovAttentionChange?.(201, 1, true)}>
+        Add validator MOV note
+      </button>
+      <button onClick={() => props.onMovAttentionChange?.(201, 1, false)}>
+        Clear validator MOV note
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("@/components/features/assessments/tree-navigation", () => ({
@@ -356,6 +365,63 @@ describe("ValidatorValidationClient autosave", () => {
     });
 
     render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    expectSidebarAttention(201, true);
+  });
+
+  it("updates the validator sidebar warning state immediately when a MOV note is added locally", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    expectSidebarAttention(201, false);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Add validator MOV note" })[0]);
+
+    expectSidebarAttention(201, true);
+  });
+
+  it("clears the validator sidebar warning state when the only local MOV attention is removed", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Add validator MOV note" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Clear validator MOV note" })[0]);
+
+    expectSidebarAttention(201, false);
+  });
+
+  it("keeps saved server MOV attention after a local override is cleared", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment({
+        movs: [
+          {
+            id: 1,
+            uploaded_at: "2024-01-01T00:00:00Z",
+            validator_notes: "saved note",
+            flagged_for_calibration: false,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Clear validator MOV note" })[0]);
 
     expectSidebarAttention(201, true);
   });


### PR DESCRIPTION
## Changes
- Updated `AssessmentTreeNode` to support warning and danger variants for MOV attention.
- Integrated `onMovAttentionChange` callback in `ValidatorValidationClient` to sync local file flags with the sidebar.
- Ensured validator MOV attention (notes and calibration flags) persists in the sidebar after saving.
- Added comprehensive tests for the validator sidebar warning icons and autosave persistence.

Fixes SNG-34.