### PR TITLE
feat(validator): improve MOV review tracking and progress reporting

### DIFF
--- a/apps/api/app/schemas/mlgoo.py
+++ b/apps/api/app/schemas/mlgoo.py
@@ -310,6 +310,8 @@ class AssessorProgressItem(BaseModel):
     assessor_id: int | None
     assessor_name: str | None
     status: str  # pending, in_progress, reviewed, sent_for_rework
+    reviewed_indicators: int = Field(default=0, ge=0)
+    total_indicators: int = Field(default=0, ge=0)
     progress_percent: int = Field(ge=0, le=100)
     label: str
 

--- a/apps/api/app/services/assessor_service.py
+++ b/apps/api/app/services/assessor_service.py
@@ -410,7 +410,7 @@ class AssessorService:
                                     k.startswith("assessor_val_") for k in r.response_data.keys()
                                 )
                                 and r.updated_at
-                                and r.updated_at >= resubmit_timestamp
+                                and r.updated_at > resubmit_timestamp
                             )
                             re_review_progress = round(
                                 (re_reviewed_count / total_count * 100) if total_count > 0 else 0
@@ -428,7 +428,7 @@ class AssessorService:
                         for r in area_responses
                         if not r.requires_rework
                         and r.updated_at
-                        and r.updated_at >= a.calibration_submitted_at
+                        and r.updated_at > a.calibration_submitted_at
                         and (
                             r.validation_status is not None
                             or r.flagged_for_calibration

--- a/apps/api/app/services/mlgoo_service.py
+++ b/apps/api/app/services/mlgoo_service.py
@@ -207,7 +207,14 @@ class MLGOOService:
                 assessor_reviewed_indicators = total_indicators
                 assessor_progress_percent = 100
                 assessors_completed_count += 1
-            elif raw_area_status in {"submitted", "in_review", "rework"}:
+            elif raw_area_status == "rework":
+                assessor_status = "sent_for_rework"
+                assessor_progress_percent = (
+                    round((assessor_reviewed_indicators / total_indicators) * 100)
+                    if total_indicators > 0
+                    else 0
+                )
+            elif raw_area_status in {"submitted", "in_review"}:
                 if assessor_reviewed_indicators == 0:
                     assessor_status = "pending" if raw_area_status == "submitted" else "in_progress"
                     assessor_progress_percent = 0
@@ -1421,15 +1428,23 @@ class MLGOOService:
                 area_payload = assessment.area_submission_status.get(
                     str(indicator.governance_area_id), {}
                 )
-                if isinstance(area_payload, dict) and area_payload.get("resubmitted_after_rework"):
-                    submitted_at_raw = area_payload.get("submitted_at")
-                    if isinstance(submitted_at_raw, str):
-                        try:
-                            area_rework_resubmitted_at = datetime.fromisoformat(
-                                submitted_at_raw.replace("Z", "+00:00")
-                            ).replace(tzinfo=None)
-                        except ValueError:
-                            area_rework_resubmitted_at = None
+                if isinstance(area_payload, dict):
+                    is_rework_resubmission = bool(
+                        area_payload.get("resubmitted_after_rework")
+                        or area_payload.get("is_resubmission")
+                        or assessment.rework_submitted_at
+                    )
+                    if is_rework_resubmission:
+                        submitted_at_raw = area_payload.get("submitted_at")
+                        if isinstance(submitted_at_raw, str):
+                            try:
+                                area_rework_resubmitted_at = datetime.fromisoformat(
+                                    submitted_at_raw.replace("Z", "+00:00")
+                                ).replace(tzinfo=None)
+                            except ValueError:
+                                area_rework_resubmitted_at = None
+                        elif assessment.rework_submitted_at:
+                            area_rework_resubmitted_at = assessment.rework_submitted_at
 
             assessor_reviewed = bool(
                 response_data

--- a/apps/api/app/services/mlgoo_service.py
+++ b/apps/api/app/services/mlgoo_service.py
@@ -166,8 +166,11 @@ class MLGOOService:
                 if indicator.get("assessor_reviewed") is True:
                     assessor_reviewed_indicators += 1
 
-                if indicator.get("validator_reviewed") is True:
+                validator_review_state = indicator.get("validator_reviewed")
+                if validator_review_state is True:
                     validated_indicators += 1
+                    continue
+                if validator_review_state is False:
                     continue
 
                 raw_status = indicator.get("validation_status")
@@ -204,20 +207,19 @@ class MLGOOService:
                 assessor_reviewed_indicators = total_indicators
                 assessor_progress_percent = 100
                 assessors_completed_count += 1
-            elif raw_area_status == "rework":
-                assessor_status = "sent_for_rework"
-                assessor_progress_percent = (
-                    round((assessor_reviewed_indicators / total_indicators) * 100)
-                    if total_indicators > 0
-                    else 0
-                )
-            elif raw_area_status == "in_review":
-                assessor_status = "in_progress"
-                assessor_progress_percent = (
-                    round((assessor_reviewed_indicators / total_indicators) * 100)
-                    if total_indicators > 0
-                    else 0
-                )
+            elif raw_area_status in {"submitted", "in_review", "rework"}:
+                if assessor_reviewed_indicators == 0:
+                    assessor_status = "pending" if raw_area_status == "submitted" else "in_progress"
+                    assessor_progress_percent = 0
+                elif assessor_reviewed_indicators < total_indicators:
+                    assessor_status = "in_progress"
+                    assessor_progress_percent = round(
+                        (assessor_reviewed_indicators / total_indicators) * 100
+                    )
+                else:
+                    assessor_status = "reviewed"
+                    assessor_progress_percent = 100
+                    assessors_completed_count += 1
             else:
                 assessor_status = "pending"
                 assessor_progress_percent = 0
@@ -238,6 +240,8 @@ class MLGOOService:
                         "assessor_id": assessor_id,
                         "assessor_name": assessor_name,
                         "status": assessor_status,
+                        "reviewed_indicators": assessor_reviewed_indicators,
+                        "total_indicators": total_indicators,
                         "progress_percent": assessor_progress_percent,
                         "label": assessor_label(assessor_status),
                     },
@@ -1433,29 +1437,46 @@ class MLGOOService:
             )
             validator_reviewed = bool(response and response.validation_status is not None)
 
-            # Rework/calibration indicators are not considered reviewed until re-reviewed after resubmission.
-            if response and response.requires_rework:
-                assessor_reviewed = False
-                validator_reviewed = False
-
-            if (
+            requires_assessor_rereview = bool(response and response.requires_rework)
+            requires_validator_rereview = bool(response and response.flagged_for_calibration)
+            requires_mlgoo_rereview = bool(
                 response
-                and assessor_reviewed
-                and area_rework_resubmitted_at
-                and (not response.updated_at or response.updated_at < area_rework_resubmitted_at)
-            ):
-                assessor_reviewed = False
+                and response.indicator_id in (assessment.mlgoo_recalibration_indicator_ids or [])
+            )
 
-            if (
-                response
-                and validator_reviewed
-                and assessment.calibration_submitted_at
-                and (
-                    not response.updated_at
-                    or response.updated_at < assessment.calibration_submitted_at
-                )
-            ):
-                validator_reviewed = False
+            if requires_assessor_rereview:
+                if area_rework_resubmitted_at:
+                    assessor_reviewed = bool(
+                        response
+                        and response.updated_at
+                        and response.updated_at > area_rework_resubmitted_at
+                        and response_data
+                        and any(key.startswith("assessor_val_") for key in response_data.keys())
+                    )
+                else:
+                    assessor_reviewed = False
+
+            if requires_validator_rereview:
+                if assessment.calibration_submitted_at:
+                    validator_reviewed = bool(
+                        response
+                        and response.updated_at
+                        and response.updated_at > assessment.calibration_submitted_at
+                        and response.validation_status is not None
+                    )
+                else:
+                    validator_reviewed = False
+
+            if requires_mlgoo_rereview:
+                if assessment.mlgoo_recalibration_submitted_at:
+                    validator_reviewed = bool(
+                        response
+                        and response.updated_at
+                        and response.updated_at > assessment.mlgoo_recalibration_submitted_at
+                        and response.validation_status is not None
+                    )
+                else:
+                    validator_reviewed = False
 
             # Count statuses (only for indicators with responses and validation status)
             if response and response.validation_status:

--- a/apps/api/tests/api/v1/test_blgu_dashboard_rework_progress.py
+++ b/apps/api/tests/api/v1/test_blgu_dashboard_rework_progress.py
@@ -9,6 +9,7 @@ from app.db.enums import AreaType, AssessmentStatus, UserRole
 from app.db.models.assessment import Assessment, AssessmentResponse, MOVFile
 from app.db.models.barangay import Barangay
 from app.db.models.governance_area import GovernanceArea, Indicator
+from app.db.models.system import AssessmentYear
 from app.db.models.user import User
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -71,8 +72,24 @@ def test_dashboard_only_marks_completed_flagged_indicators_as_addressed(
     db_session.flush()
 
     requested_at = datetime.now(UTC) - timedelta(days=2)
+    assessment_year = AssessmentYear(
+        year=2026,
+        assessment_period_start=requested_at - timedelta(days=90),
+        assessment_period_end=requested_at + timedelta(days=90),
+        phase1_deadline=requested_at - timedelta(days=1),
+        submission_window_days=60,
+        rework_window_days=5,
+        calibration_window_days=3,
+        default_unlock_grace_period_days=5,
+        is_active=True,
+        is_published=True,
+    )
+    db_session.add(assessment_year)
+    db_session.flush()
+
     assessment = Assessment(
         blgu_user_id=user.id,
+        assessment_year=assessment_year.year,
         status=AssessmentStatus.NEEDS_REWORK,
         rework_count=1,
         rework_requested_at=requested_at,

--- a/apps/api/tests/services/test_assessor_service_noop_validation.py
+++ b/apps/api/tests/services/test_assessor_service_noop_validation.py
@@ -348,6 +348,68 @@ def test_get_validator_queue_does_not_count_false_only_checklist_data_as_reviewe
     assert queue[0]["re_review_progress"] == 0
 
 
+def test_get_assessor_queue_re_review_progress_requires_update_after_area_resubmission(
+    db_session, mock_governance_area
+):
+    response = create_validation_context(db_session, mock_governance_area)
+
+    assessor = User(
+        email="strict-re-review-assessor@test.com",
+        name="Strict Re-review Assessor",
+        role=UserRole.ASSESSOR,
+        assessor_area_id=mock_governance_area.id,
+        hashed_password="hashed_password",
+        is_active=True,
+    )
+    db_session.add(assessor)
+    db_session.commit()
+    db_session.refresh(assessor)
+
+    resubmitted_at = datetime(2025, 2, 2, 9, 0, 0)
+    assessment = response.assessment
+    assessment.status = AssessmentStatus.SUBMITTED_FOR_REVIEW
+    assessment.submitted_at = datetime(2025, 2, 1, 9, 0, 0)
+    assessment.area_submission_status = {
+        str(mock_governance_area.id): {
+            "status": "submitted",
+            "submitted_at": resubmitted_at.isoformat(),
+            "resubmitted_after_rework": True,
+        }
+    }
+    response.response_data = {"assessor_val_item_1": True}
+    response.requires_rework = False
+    response.updated_at = resubmitted_at
+    db_session.add_all([assessment, response])
+    db_session.commit()
+
+    queue = assessor_service.get_assessor_queue(db_session, assessor, assessment_year=2025)
+
+    assert len(queue) == 1
+    assert queue[0]["re_review_progress"] == 0
+
+
+def test_get_validator_queue_re_review_progress_requires_update_after_calibration_submission(
+    db_session, mock_governance_area, validator_user
+):
+    response = create_validation_context(db_session, mock_governance_area)
+
+    calibration_submitted_at = datetime(2025, 2, 2, 9, 0, 0)
+    assessment = response.assessment
+    assessment.status = AssessmentStatus.AWAITING_FINAL_VALIDATION
+    assessment.submitted_at = datetime(2025, 2, 1, 9, 0, 0)
+    assessment.calibration_submitted_at = calibration_submitted_at
+    response.validation_status = ValidationStatus.PASS
+    response.requires_rework = False
+    response.updated_at = calibration_submitted_at
+    db_session.add_all([assessment, response])
+    db_session.commit()
+
+    queue = assessor_service.get_assessor_queue(db_session, validator_user, assessment_year=2025)
+
+    assert len(queue) == 1
+    assert queue[0]["re_review_progress"] == 0
+
+
 def test_get_validator_queue_phase_gating_excludes_submitted_but_keeps_validation_and_calibration_rework(
     db_session, mock_governance_area, validator_user
 ):

--- a/apps/api/tests/services/test_mlgoo_service.py
+++ b/apps/api/tests/services/test_mlgoo_service.py
@@ -443,3 +443,100 @@ def test_get_assessment_details_keeps_cumulative_assessor_progress_after_rework_
     assert area_progress["assessor"]["total_indicators"] == 9
     assert area_progress["assessor"]["progress_percent"] == 89
     assert area_progress["assessor"]["status"] == "in_progress"
+
+
+def test_get_assessment_details_keeps_mlgoo_recalibration_target_pending_until_later_validation(
+    db_session,
+    mlgoo_user: User,
+    mock_blgu_user: User,
+    active_assessment_year: AssessmentYear,
+    mock_governance_area,
+):
+    from app.db.enums import ValidationStatus
+
+    parent = Indicator(
+        name="Recalibration Parent",
+        indicator_code="R",
+        governance_area_id=mock_governance_area.id,
+        sort_order=0,
+        description="Parent grouping",
+    )
+    db_session.add(parent)
+    db_session.flush()
+
+    reviewed_indicator = Indicator(
+        name="Reviewed Indicator",
+        indicator_code="1.1",
+        governance_area_id=mock_governance_area.id,
+        parent_id=parent.id,
+        sort_order=1,
+        description="Reviewed indicator",
+    )
+    recalibration_indicator = Indicator(
+        name="Recalibration Indicator",
+        indicator_code="1.2",
+        governance_area_id=mock_governance_area.id,
+        parent_id=parent.id,
+        sort_order=2,
+        description="Recalibration indicator",
+    )
+    db_session.add_all([reviewed_indicator, recalibration_indicator])
+    db_session.flush()
+
+    recalibration_submitted_at = datetime(2026, 4, 11, 9, 0, 0)
+    assessment = Assessment(
+        blgu_user_id=mock_blgu_user.id,
+        assessment_year=active_assessment_year.year,
+        status=AssessmentStatus.AWAITING_MLGOO_APPROVAL,
+        is_mlgoo_recalibration=True,
+        mlgoo_recalibration_indicator_ids=[recalibration_indicator.id],
+        mlgoo_recalibration_requested_at=datetime(2026, 4, 10, 8, 0, 0),
+        mlgoo_recalibration_submitted_at=recalibration_submitted_at,
+    )
+    db_session.add(assessment)
+    db_session.flush()
+
+    db_session.add_all(
+        [
+            AssessmentResponse(
+                assessment_id=assessment.id,
+                indicator_id=reviewed_indicator.id,
+                response_data={"assessor_val_status": "complete"},
+                is_completed=True,
+                validation_status=ValidationStatus.PASS,
+                updated_at=recalibration_submitted_at - timedelta(hours=2),
+            ),
+            AssessmentResponse(
+                assessment_id=assessment.id,
+                indicator_id=recalibration_indicator.id,
+                response_data={"assessor_val_status": "complete"},
+                is_completed=True,
+                validation_status=ValidationStatus.PASS,
+                updated_at=recalibration_submitted_at,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    details = mlgoo_service.get_assessment_details(
+        db=db_session,
+        assessment_id=assessment.id,
+        mlgoo_user=mlgoo_user,
+    )
+
+    [area_progress] = [
+        area
+        for area in details["assessment_progress"]["governance_areas"]
+        if area["governance_area_id"] == mock_governance_area.id
+    ]
+    [target_indicator] = [
+        indicator
+        for area in details["governance_areas"]
+        for indicator in area["indicators"]
+        if indicator["indicator_id"] == recalibration_indicator.id
+    ]
+
+    assert area_progress["validator"]["reviewed_indicators"] == 1
+    assert area_progress["validator"]["total_indicators"] == 2
+    assert area_progress["validator"]["progress_percent"] == 50
+    assert target_indicator["validator_reviewed"] is False

--- a/apps/api/tests/services/test_mlgoo_service.py
+++ b/apps/api/tests/services/test_mlgoo_service.py
@@ -445,6 +445,170 @@ def test_get_assessment_details_keeps_cumulative_assessor_progress_after_rework_
     assert area_progress["assessor"]["status"] == "in_progress"
 
 
+def test_get_assessment_details_preserves_sent_for_rework_status_with_counted_progress(
+    db_session,
+    mlgoo_user: User,
+    mock_blgu_user: User,
+    active_assessment_year: AssessmentYear,
+    mock_governance_area,
+):
+    from app.db.enums import ValidationStatus
+
+    parent = Indicator(
+        name="Rework Parent",
+        indicator_code="RW",
+        governance_area_id=mock_governance_area.id,
+        sort_order=0,
+        description="Parent grouping",
+    )
+    db_session.add(parent)
+    db_session.flush()
+
+    reviewed_indicator = Indicator(
+        name="Reviewed Indicator",
+        indicator_code="1.1",
+        governance_area_id=mock_governance_area.id,
+        parent_id=parent.id,
+        sort_order=1,
+        description="Reviewed indicator",
+    )
+    rework_indicator = Indicator(
+        name="Rework Indicator",
+        indicator_code="1.2",
+        governance_area_id=mock_governance_area.id,
+        parent_id=parent.id,
+        sort_order=2,
+        description="Rework indicator",
+    )
+    db_session.add_all([reviewed_indicator, rework_indicator])
+    db_session.flush()
+
+    assessment = Assessment(
+        blgu_user_id=mock_blgu_user.id,
+        assessment_year=active_assessment_year.year,
+        status=AssessmentStatus.SUBMITTED_FOR_REVIEW,
+        rework_count=1,
+        area_submission_status={str(mock_governance_area.id): {"status": "rework"}},
+        area_assessor_approved={str(mock_governance_area.id): False},
+    )
+    db_session.add(assessment)
+    db_session.flush()
+
+    db_session.add_all(
+        [
+            AssessmentResponse(
+                assessment_id=assessment.id,
+                indicator_id=reviewed_indicator.id,
+                response_data={"assessor_val_status": "complete"},
+                is_completed=True,
+                validation_status=ValidationStatus.PASS,
+                updated_at=datetime(2026, 4, 10, 8, 0, 0),
+            ),
+            AssessmentResponse(
+                assessment_id=assessment.id,
+                indicator_id=rework_indicator.id,
+                response_data={"assessor_val_status": "complete"},
+                is_completed=False,
+                requires_rework=True,
+                updated_at=datetime(2026, 4, 10, 8, 0, 0),
+            ),
+        ]
+    )
+    db_session.commit()
+
+    details = mlgoo_service.get_assessment_details(
+        db=db_session,
+        assessment_id=assessment.id,
+        mlgoo_user=mlgoo_user,
+    )
+
+    [area_progress] = [
+        area
+        for area in details["assessment_progress"]["governance_areas"]
+        if area["governance_area_id"] == mock_governance_area.id
+    ]
+
+    assert area_progress["assessor"]["status"] == "sent_for_rework"
+    assert area_progress["assessor"]["reviewed_indicators"] == 1
+    assert area_progress["assessor"]["total_indicators"] == 2
+    assert area_progress["assessor"]["progress_percent"] == 50
+
+
+def test_get_assessment_details_supports_legacy_rework_resubmission_flag(
+    db_session,
+    mlgoo_user: User,
+    mock_blgu_user: User,
+    active_assessment_year: AssessmentYear,
+    mock_governance_area,
+):
+    parent = Indicator(
+        name="Legacy Parent",
+        indicator_code="LG",
+        governance_area_id=mock_governance_area.id,
+        sort_order=0,
+        description="Parent grouping",
+    )
+    db_session.add(parent)
+    db_session.flush()
+
+    indicator = Indicator(
+        name="Legacy Rework Indicator",
+        indicator_code="1.1",
+        governance_area_id=mock_governance_area.id,
+        parent_id=parent.id,
+        sort_order=1,
+        description="Legacy rework indicator",
+    )
+    db_session.add(indicator)
+    db_session.flush()
+
+    resubmitted_at = datetime(2026, 4, 11, 9, 0, 0)
+    assessment = Assessment(
+        blgu_user_id=mock_blgu_user.id,
+        assessment_year=active_assessment_year.year,
+        status=AssessmentStatus.SUBMITTED_FOR_REVIEW,
+        rework_count=1,
+        area_submission_status={
+            str(mock_governance_area.id): {
+                "status": "submitted",
+                "submitted_at": resubmitted_at.isoformat(),
+                "is_resubmission": True,
+            }
+        },
+        area_assessor_approved={str(mock_governance_area.id): False},
+    )
+    db_session.add(assessment)
+    db_session.flush()
+
+    db_session.add(
+        AssessmentResponse(
+            assessment_id=assessment.id,
+            indicator_id=indicator.id,
+            response_data={"assessor_val_status": "complete"},
+            is_completed=True,
+            requires_rework=True,
+            updated_at=resubmitted_at + timedelta(minutes=1),
+        )
+    )
+    db_session.commit()
+
+    details = mlgoo_service.get_assessment_details(
+        db=db_session,
+        assessment_id=assessment.id,
+        mlgoo_user=mlgoo_user,
+    )
+
+    [area_progress] = [
+        area
+        for area in details["assessment_progress"]["governance_areas"]
+        if area["governance_area_id"] == mock_governance_area.id
+    ]
+
+    assert area_progress["assessor"]["reviewed_indicators"] == 1
+    assert area_progress["assessor"]["progress_percent"] == 100
+    assert area_progress["assessor"]["status"] == "reviewed"
+
+
 def test_get_assessment_details_keeps_mlgoo_recalibration_target_pending_until_later_validation(
     db_session,
     mlgoo_user: User,

--- a/apps/api/tests/services/test_mlgoo_service.py
+++ b/apps/api/tests/services/test_mlgoo_service.py
@@ -343,3 +343,103 @@ def test_get_assessment_details_keeps_all_mov_files_for_indicator_with_upload_or
         MOV_UPLOAD_ORIGIN_BLGU,
         MOV_UPLOAD_ORIGIN_VALIDATOR,
     ]
+
+
+def test_get_assessment_details_keeps_cumulative_assessor_progress_after_rework_resubmission(
+    db_session,
+    mlgoo_user: User,
+    mock_blgu_user: User,
+    active_assessment_year: AssessmentYear,
+    mock_governance_area,
+):
+    from app.db.enums import UserRole, ValidationStatus
+
+    assessor = User(
+        email="progress-assessor@test.gov.ph",
+        name="Progress Assessor",
+        hashed_password="test",
+        role=UserRole.ASSESSOR,
+        assessor_area_id=mock_governance_area.id,
+        is_active=True,
+    )
+    db_session.add(assessor)
+    db_session.flush()
+
+    parent = Indicator(
+        name="Progress Parent",
+        indicator_code="P",
+        governance_area_id=mock_governance_area.id,
+        sort_order=0,
+        description="Parent grouping",
+    )
+    db_session.add(parent)
+    db_session.flush()
+
+    indicators = []
+    for index in range(1, 10):
+        indicator = Indicator(
+            name=f"Progress Indicator {index}",
+            indicator_code=f"1.{index}",
+            governance_area_id=mock_governance_area.id,
+            parent_id=parent.id,
+            sort_order=index,
+            description=f"Indicator {index}",
+        )
+        db_session.add(indicator)
+        indicators.append(indicator)
+    db_session.flush()
+
+    rework_requested_at = datetime(2026, 4, 10, 8, 0, 0)
+    resubmitted_at = datetime(2026, 4, 11, 9, 0, 0)
+    assessment = Assessment(
+        blgu_user_id=mock_blgu_user.id,
+        assessment_year=active_assessment_year.year,
+        status=AssessmentStatus.SUBMITTED_FOR_REVIEW,
+        rework_count=1,
+        rework_requested_at=rework_requested_at,
+        area_submission_status={
+            str(mock_governance_area.id): {
+                "status": "submitted",
+                "assessor_id": assessor.id,
+                "submitted_at": resubmitted_at.isoformat(),
+                "resubmitted_after_rework": True,
+            }
+        },
+        area_assessor_approved={str(mock_governance_area.id): False},
+    )
+    db_session.add(assessment)
+    db_session.flush()
+
+    for index, indicator in enumerate(indicators, start=1):
+        is_rework_indicator = index == 9
+        reviewed_at = resubmitted_at - timedelta(hours=2)
+        response = AssessmentResponse(
+            assessment_id=assessment.id,
+            indicator_id=indicator.id,
+            response_data={"assessor_val_status": "complete"},
+            is_completed=not is_rework_indicator,
+            requires_rework=is_rework_indicator,
+            validation_status=ValidationStatus.PASS if not is_rework_indicator else None,
+            updated_at=reviewed_at,
+        )
+        db_session.add(response)
+
+    db_session.commit()
+
+    details = mlgoo_service.get_assessment_details(
+        db=db_session,
+        assessment_id=assessment.id,
+        mlgoo_user=mlgoo_user,
+    )
+
+    [area_progress] = [
+        area
+        for area in details["assessment_progress"]["governance_areas"]
+        if area["governance_area_id"] == mock_governance_area.id
+    ]
+
+    assert area_progress["total_indicators"] == 9
+    assert area_progress["assessor"]["reviewed_indicators"] == 8
+    assert area_progress["assessor"]["total_indicators"] == 9
+    assert area_progress["assessor"]["progress_percent"] == 89
+    assert area_progress["assessor"]["status"] == "in_progress"

--- a/apps/web/src/app/(app)/mlgoo/submissions/[id]/page.tsx
+++ b/apps/web/src/app/(app)/mlgoo/submissions/[id]/page.tsx
@@ -276,6 +276,8 @@ interface AssessorProgressData {
   assessor_id?: number | null;
   assessor_name?: string | null;
   status?: string;
+  reviewed_indicators?: number;
+  total_indicators?: number;
   progress_percent?: number;
   label?: string;
 }
@@ -2412,7 +2414,8 @@ export default function SubmissionDetailsPage() {
                     const assessorName =
                       areaProgress.assessor.assessor_name || "Unassigned Assessor";
                     const validatorDisplayName = "Validators";
-                    const assessorTotalIndicators = areaProgress.total_indicators || 0;
+                    const assessorTotalIndicators =
+                      areaProgress.assessor.total_indicators || areaProgress.total_indicators || 0;
                     const fallbackAssessorReviewedIndicators = [
                       "reviewed",
                       "sent_for_rework",
@@ -2445,10 +2448,13 @@ export default function SubmissionDetailsPage() {
                         sensitivity: "base",
                       })
                     );
+                    const apiAssessorReviewedIndicators = areaProgress.assessor.reviewed_indicators;
                     const assessorReviewedIndicators =
-                      sortedIndicators.length > 0
-                        ? sortedIndicators.filter(isAssessorIndicatorCompleted).length
-                        : fallbackAssessorReviewedIndicators;
+                      typeof apiAssessorReviewedIndicators === "number"
+                        ? apiAssessorReviewedIndicators
+                        : sortedIndicators.length > 0
+                          ? sortedIndicators.filter(isAssessorIndicatorCompleted).length
+                          : fallbackAssessorReviewedIndicators;
                     const validatorReviewedIndicators =
                       sortedIndicators.length > 0
                         ? sortedIndicators.filter(isValidatorIndicatorCompleted).length

--- a/apps/web/src/components/features/assessments/tree-navigation/AssessmentTreeNode.tsx
+++ b/apps/web/src/components/features/assessments/tree-navigation/AssessmentTreeNode.tsx
@@ -40,6 +40,7 @@ interface AssessmentTreeNodeProps {
   // Per-area rework/calibration tracking
   remainingAttempts?: { reworkLeft: boolean; calibrationLeft: boolean };
   isAssessmentLockedForBlgu?: boolean;
+  movAttentionVariant?: "warning" | "danger";
 }
 
 export function AssessmentTreeNode({
@@ -58,6 +59,7 @@ export function AssessmentTreeNode({
   onAreaSubmitSuccess,
   remainingAttempts,
   isAssessmentLockedForBlgu = false,
+  movAttentionVariant = "warning",
 }: AssessmentTreeNodeProps) {
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -160,19 +162,47 @@ export function AssessmentTreeNode({
 
     // Show yellow warning for indicators with MOV notes or flagged files
     if (indicator.hasMovNotes) {
-      // If also completed, show warning triangle (notes take visual priority)
-      return <AlertTriangle className="h-3.5 w-3.5 text-yellow-500" aria-hidden="true" />;
+      // If also completed, MOV attention takes visual priority.
+      if (movAttentionVariant === "danger") {
+        return (
+          <AlertCircle
+            className="h-3.5 w-3.5 text-red-500"
+            aria-label="Indicator needs attention"
+          />
+        );
+      }
+
+      return (
+        <AlertTriangle
+          className="h-3.5 w-3.5 text-yellow-500"
+          aria-label="Indicator has MOV notes"
+        />
+      );
     }
 
     switch (indicator.status) {
       case "completed":
-        return <CheckCircle className="h-3.5 w-3.5 text-green-500" aria-hidden="true" />;
+        return (
+          <CheckCircle className="h-3.5 w-3.5 text-green-500" aria-label="Indicator complete" />
+        );
       case "flagged_for_rework":
-        return <AlertTriangle className="h-3.5 w-3.5 text-orange-500" aria-hidden="true" />;
+        return (
+          <AlertTriangle
+            className="h-3.5 w-3.5 text-orange-500"
+            aria-label="Indicator flagged for rework"
+          />
+        );
       case "needs_rework":
-        return <AlertCircle className="h-3.5 w-3.5 text-orange-500" aria-hidden="true" />;
+        return (
+          <AlertCircle
+            className="h-3.5 w-3.5 text-orange-500"
+            aria-label="Indicator needs rework"
+          />
+        );
       default:
-        return <Circle className="h-3.5 w-3.5 text-[var(--border)]" aria-hidden="true" />;
+        return (
+          <Circle className="h-3.5 w-3.5 text-[var(--border)]" aria-label="Indicator not started" />
+        );
     }
   };
 

--- a/apps/web/src/components/features/assessments/tree-navigation/TreeNavigator.tsx
+++ b/apps/web/src/components/features/assessments/tree-navigation/TreeNavigator.tsx
@@ -33,6 +33,7 @@ interface TreeNavigatorProps {
   onAreaSubmitSuccess?: () => void;
   areaAssessorStatus?: AreaAssessorStatusItem[];
   isAssessmentLockedForBlgu?: boolean;
+  movAttentionVariant?: "warning" | "danger";
 }
 
 export function TreeNavigator({
@@ -43,6 +44,7 @@ export function TreeNavigator({
   onAreaSubmitSuccess,
   areaAssessorStatus,
   isAssessmentLockedForBlgu = false,
+  movAttentionVariant = "warning",
 }: TreeNavigatorProps) {
   // Load expanded state from sessionStorage or auto-expand first incomplete
   const [expandedAreas, setExpandedAreas] = useState<Set<string>>(() => {
@@ -119,6 +121,7 @@ export function TreeNavigator({
             isActive={selectedIndicatorId === indicator.id}
             onClick={() => handleIndicatorClick(indicator.id)}
             level={level}
+            movAttentionVariant={movAttentionVariant}
           />
         </div>
       );

--- a/apps/web/src/components/features/assessments/tree-navigation/__tests__/AssessmentTreeNode.test.tsx
+++ b/apps/web/src/components/features/assessments/tree-navigation/__tests__/AssessmentTreeNode.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AssessmentTreeNode } from "../AssessmentTreeNode";
+import type { Indicator } from "@/types/assessment";
+
+function makeIndicator(overrides: Partial<Indicator> = {}): Indicator {
+  return {
+    id: "201",
+    code: "1.3.1",
+    name: "Presence of a Barangay Appropriation Ordinance",
+    description: "",
+    technicalNotes: "",
+    governanceAreaId: "1",
+    status: "completed",
+    movFiles: [],
+    formSchema: { properties: {} },
+    ...overrides,
+  };
+}
+
+describe("AssessmentTreeNode", () => {
+  it("keeps the default yellow MOV attention icon for shared non-validator trees", () => {
+    render(
+      <AssessmentTreeNode
+        type="indicator"
+        item={makeIndicator({ hasMovNotes: true, status: "completed" })}
+      />
+    );
+
+    const icon = screen.getByLabelText("Indicator has MOV notes");
+    expect(icon).toHaveClass("text-yellow-500");
+    expect(screen.queryByLabelText("Indicator complete")).not.toBeInTheDocument();
+  });
+
+  it("shows a red warning icon before the completed icon for validator MOV attention", () => {
+    render(
+      <AssessmentTreeNode
+        type="indicator"
+        item={makeIndicator({ hasMovNotes: true, status: "completed" })}
+        movAttentionVariant="danger"
+      />
+    );
+
+    const icon = screen.getByLabelText("Indicator needs attention");
+    expect(icon).toHaveClass("text-red-500");
+    expect(screen.queryByLabelText("Indicator complete")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
+++ b/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
@@ -260,6 +260,8 @@ interface MiddleMovFilesPanelProps {
   onReworkFlagSaved?: (responseId: number, movFileId: number, flagged: boolean) => void;
   /** Callback when validator toggles calibration flag (validators only) */
   onCalibrationFlagChange?: (responseId: number, flagged: boolean) => void;
+  /** Callback while validator MOV note/flag edits make one open file need attention */
+  onMovAttentionChange?: (responseId: number, movFileId: number, hasAttention: boolean) => void;
 }
 
 type AnyRecord = Record<string, any>;
@@ -431,6 +433,7 @@ export function MiddleMovFilesPanel({
   onAnnotationDeleted,
   onReworkFlagSaved,
   onCalibrationFlagChange,
+  onMovAttentionChange,
 }: MiddleMovFilesPanelProps) {
   const { user } = useAuthStore();
   const isValidator = user?.role === "VALIDATOR";
@@ -682,6 +685,20 @@ export function MiddleMovFilesPanel({
       setFeedbackDirty(false);
     }
   }, [isAnnotating]);
+
+  React.useEffect(() => {
+    if (!isValidator || !expandedId || !selectedFile?.id || !onMovAttentionChange) return;
+
+    const currentResponseId = expandedId;
+    const currentMovFileId = selectedFile.id;
+    const hasAttention = movFlagged || movNotes.trim().length > 0;
+
+    onMovAttentionChange(currentResponseId, currentMovFileId, hasAttention);
+
+    return () => {
+      onMovAttentionChange(currentResponseId, currentMovFileId, false);
+    };
+  }, [movNotes, movFlagged, isValidator, expandedId, selectedFile?.id, onMovAttentionChange]);
 
   // Auto-toggle flag when notes are added
   const handleNotesChange = (value: string) => {

--- a/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
+++ b/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
@@ -305,6 +305,62 @@ function sortFilesByUploadedAtDesc<T extends { uploaded_at?: string | null }>(fi
   });
 }
 
+function patchMovFeedbackInAssessmentCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  assessmentId: number,
+  movFileId: number,
+  feedback: AnyRecord
+) {
+  if (assessmentId <= 0) return;
+
+  const queryKey = getGetAssessorAssessmentsAssessmentIdQueryKey(assessmentId);
+
+  queryClient.setQueryData(queryKey, (current: unknown) => {
+    if (!current || typeof current !== "object") return current;
+
+    const root = current as AnyRecord;
+    const core = (root.assessment as AnyRecord | undefined) ?? root;
+    const responses = Array.isArray(core.responses) ? core.responses : null;
+    if (!responses) return current;
+
+    let didUpdateMov = false;
+    const nextResponses = responses.map((response: AnyRecord) => {
+      const movs = Array.isArray(response.movs) ? response.movs : null;
+      if (!movs) return response;
+
+      const nextMovs = movs.map((mov: AnyRecord) => {
+        if (Number(mov.id) !== movFileId) return mov;
+
+        didUpdateMov = true;
+        return {
+          ...mov,
+          assessor_notes:
+            feedback.assessor_notes !== undefined ? feedback.assessor_notes : mov.assessor_notes,
+          flagged_for_rework:
+            feedback.flagged_for_rework !== undefined
+              ? feedback.flagged_for_rework
+              : mov.flagged_for_rework,
+          validator_notes:
+            feedback.validator_notes !== undefined ? feedback.validator_notes : mov.validator_notes,
+          flagged_for_calibration:
+            feedback.flagged_for_calibration !== undefined
+              ? feedback.flagged_for_calibration
+              : mov.flagged_for_calibration,
+        };
+      });
+
+      return didUpdateMov ? { ...response, movs: nextMovs } : response;
+    });
+
+    if (!didUpdateMov) return current;
+
+    const nextCore = { ...core, responses: nextResponses };
+    return root.assessment ? { ...root, assessment: nextCore } : nextCore;
+  });
+
+  void queryClient.invalidateQueries({ queryKey, refetchType: "active" });
+}
+
 function ReviewFileSection({
   title,
   files,
@@ -644,6 +700,12 @@ export function MiddleMovFilesPanel({
       onSuccess: (_data, variables) => {
         toast.success("Feedback saved");
         setFeedbackDirty(false);
+        patchMovFeedbackInAssessmentCache(
+          queryClient,
+          assessmentId,
+          variables.movFileId,
+          variables.data as AnyRecord
+        );
         const flaggedValue = isValidator
           ? (variables.data as AnyRecord).flagged_for_calibration
           : (variables.data as AnyRecord).flagged_for_rework;

--- a/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
+++ b/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
@@ -83,14 +83,14 @@ function getUploadedAtMs(file: AnyRecord): number {
   return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
-function groupValidatorFilesForDisplay(files: AnyRecord[]): {
-  newFiles: AnyRecord[];
-  acceptedOldFiles: AnyRecord[];
-  rejectedOldFiles: AnyRecord[];
+function groupValidatorFilesForDisplay(files: (MOVFileResponse & AnyRecord)[]): {
+  newFiles: (MOVFileResponse & AnyRecord)[];
+  acceptedOldFiles: (MOVFileResponse & AnyRecord)[];
+  rejectedOldFiles: (MOVFileResponse & AnyRecord)[];
 } {
-  const newFiles: AnyRecord[] = [];
-  const acceptedOldFiles: AnyRecord[] = [];
-  const rejectedOldFiles: AnyRecord[] = [];
+  const newFiles: (MOVFileResponse & AnyRecord)[] = [];
+  const acceptedOldFiles: (MOVFileResponse & AnyRecord)[] = [];
+  const rejectedOldFiles: (MOVFileResponse & AnyRecord)[] = [];
 
   for (const file of files) {
     const uploadedAt = getUploadedAtMs(file);
@@ -379,7 +379,7 @@ function ReviewFileSection({
   downloadingFileId = null,
 }: {
   title: string;
-  files: MOVFileResponse[];
+  files: (MOVFileResponse & AnyRecord)[];
   historyLabel?: string;
   collapseHistory?: boolean;
   badgeClassName?: string;
@@ -429,6 +429,7 @@ function ReviewFileSection({
         loading={false}
         emptyMessage=""
         movAnnotations={movAnnotations}
+        hideHeader={true}
       />
 
       {archivedFiles.length > 0 && (
@@ -467,6 +468,7 @@ function ReviewFileSection({
                 loading={false}
                 emptyMessage=""
                 movAnnotations={movAnnotations}
+                hideHeader={true}
               />
               {description && (
                 <p className="mt-2 text-xs text-slate-600 dark:text-slate-400">{description}</p>
@@ -606,7 +608,7 @@ export function MiddleMovFilesPanel({
   }, [selectedResponse, calibrationRequestedAt, reworkRequestedAt, separationLabel]);
 
   // Get MOV files from the selected response with isNew flag for calibration separation
-  const movFiles = React.useMemo(() => {
+  const movFiles = React.useMemo<(MOVFileResponse & AnyRecord)[]>(() => {
     if (!selectedResponse) return [];
 
     // MOV files are in the 'movs' array according to the backend schema
@@ -971,7 +973,7 @@ export function MiddleMovFilesPanel({
     [handleDeleteAnnotation]
   );
 
-  const normalPreviousFiles = React.useMemo(
+  const normalPreviousFiles = React.useMemo<(MOVFileResponse & AnyRecord)[]>(
     () =>
       sortFilesByUploadedAtDesc(
         movFiles.filter((file) => hasReviewerNotes(file) || hasReviewerFlag(file))
@@ -979,14 +981,14 @@ export function MiddleMovFilesPanel({
     [movFiles, hasReviewerNotes, hasReviewerFlag]
   );
 
-  const barangayFiles = React.useMemo(
+  const barangayFiles = React.useMemo<(MOVFileResponse & AnyRecord)[]>(
     () =>
       sortFilesByUploadedAtDesc(
         movFiles.filter((file) => (file as AnyRecord).upload_origin !== "validator")
       ),
     [movFiles]
   );
-  const validatorFiles = React.useMemo(
+  const validatorFiles = React.useMemo<(MOVFileResponse & AnyRecord)[]>(
     () =>
       sortFilesByUploadedAtDesc(
         movFiles.filter((file) => (file as AnyRecord).upload_origin === "validator")
@@ -997,7 +999,11 @@ export function MiddleMovFilesPanel({
   // - newFiles: Files uploaded AFTER rework/calibration (replacement files)
   // - acceptedOldFiles: Files uploaded BEFORE but were accepted (no annotations, didn't need re-upload)
   // - rejectedOldFiles: Files uploaded BEFORE and were rejected/replaced
-  const { newFiles, acceptedOldFiles, rejectedOldFiles } = React.useMemo(() => {
+  const { newFiles, acceptedOldFiles, rejectedOldFiles } = React.useMemo<{
+    newFiles: (MOVFileResponse & AnyRecord)[];
+    acceptedOldFiles: (MOVFileResponse & AnyRecord)[];
+    rejectedOldFiles: (MOVFileResponse & AnyRecord)[];
+  }>(() => {
     if (!effectiveTimestamp) {
       // No separation timestamp - all files are treated as accepted (normal view)
       return { newFiles: [], acceptedOldFiles: movFiles, rejectedOldFiles: [] };
@@ -1270,6 +1276,26 @@ export function MiddleMovFilesPanel({
           </div>
         ) : effectiveTimestamp ? (
           <div className="space-y-4">
+            {validatorFiles.length > 0 && (
+              <ReviewFileSection
+                title="Validator Uploads"
+                files={validatorFiles}
+                collapseHistory={false}
+                historyLabel="View validator upload history"
+                titleClassName="text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-wide"
+                badgeClassName="text-xs text-blue-600 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/50 px-2 py-0.5 rounded-full"
+                containerClassName="rounded-sm border border-blue-200 dark:border-blue-700 bg-blue-50/60 dark:bg-blue-950/20 p-3"
+                description="Files uploaded by validators are kept separate from barangay evidence."
+                movAnnotations={safeAnnotations}
+                onPreview={handlePreview}
+                onDownload={handleDownload}
+                canDelete={canDeleteValidatorFile}
+                onDelete={handleDeleteValidatorFile}
+                deletingFileId={deletingValidatorFileId}
+                downloadingFileId={downloadingFileId}
+              />
+            )}
+
             {newFiles.length > 0 && (
               <ReviewFileSection
                 title={`Latest File (${effectiveLabel})`}
@@ -1316,26 +1342,6 @@ export function MiddleMovFilesPanel({
               />
             )}
 
-            {validatorFiles.length > 0 && (
-              <ReviewFileSection
-                title="Validator Uploads"
-                files={validatorFiles}
-                collapseHistory={false}
-                historyLabel="View validator upload history"
-                titleClassName="text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-wide"
-                badgeClassName="text-xs text-blue-600 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/50 px-2 py-0.5 rounded-full"
-                containerClassName="rounded-sm border border-blue-200 dark:border-blue-700 bg-blue-50/60 dark:bg-blue-950/20 p-3"
-                description="Files uploaded by validators are kept separate from barangay evidence."
-                movAnnotations={safeAnnotations}
-                onPreview={handlePreview}
-                onDownload={handleDownload}
-                canDelete={canDeleteValidatorFile}
-                onDelete={handleDeleteValidatorFile}
-                deletingFileId={deletingValidatorFileId}
-                downloadingFileId={downloadingFileId}
-              />
-            )}
-
             {/* No files at all */}
             {newFiles.length === 0 &&
               acceptedOldFiles.length === 0 &&
@@ -1351,20 +1357,6 @@ export function MiddleMovFilesPanel({
           </div>
         ) : (
           <div className="space-y-4">
-            <ReviewFileSection
-              title="Barangay Uploads"
-              files={barangayFiles}
-              collapseHistory={false}
-              historyLabel="View barangay upload history"
-              titleClassName="text-xs font-medium text-slate-600 dark:text-slate-400 uppercase tracking-wide"
-              badgeClassName="text-xs text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-700 px-2 py-0.5 rounded-full"
-              containerClassName="rounded-sm border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/50 p-3"
-              description="Barangay uploads remain available in history."
-              movAnnotations={safeAnnotations}
-              onPreview={handlePreview}
-              onDownload={handleDownload}
-              downloadingFileId={downloadingFileId}
-            />
             {validatorFiles.length > 0 && (
               <ReviewFileSection
                 title="Validator Uploads"
@@ -1384,6 +1376,20 @@ export function MiddleMovFilesPanel({
                 downloadingFileId={downloadingFileId}
               />
             )}
+            <ReviewFileSection
+              title="Barangay Uploads"
+              files={barangayFiles}
+              collapseHistory={false}
+              historyLabel="View barangay upload history"
+              titleClassName="text-xs font-medium text-slate-600 dark:text-slate-400 uppercase tracking-wide"
+              badgeClassName="text-xs text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-700 px-2 py-0.5 rounded-full"
+              containerClassName="rounded-sm border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/50 p-3"
+              description="Barangay uploads remain available in history."
+              movAnnotations={safeAnnotations}
+              onPreview={handlePreview}
+              onDownload={handleDownload}
+              downloadingFileId={downloadingFileId}
+            />
             {normalPreviousFiles.length > 0 && (
               <ReviewFileSection
                 title="Previous File"

--- a/apps/web/src/components/features/assessor/validation/__tests__/MiddleMovFilesPanel.test.tsx
+++ b/apps/web/src/components/features/assessor/validation/__tests__/MiddleMovFilesPanel.test.tsx
@@ -10,6 +10,7 @@ import { MiddleMovFilesPanel } from "../MiddleMovFilesPanel";
 
 const mockUploadMutate = vi.fn();
 const mockDeleteMutate = vi.fn();
+const mockPatchFeedbackMutate = vi.fn();
 let isUploadPending = false;
 
 vi.mock("@sinag/shared", () => ({
@@ -30,8 +31,11 @@ vi.mock("@sinag/shared", () => ({
     mutate: mockDeleteMutate,
     isPending: false,
   })),
-  usePatchAssessorMovsMovFileIdFeedback: vi.fn(() => ({
-    mutate: vi.fn(),
+  usePatchAssessorMovsMovFileIdFeedback: vi.fn((options: any) => ({
+    mutate: (variables: any) => {
+      mockPatchFeedbackMutate(variables);
+      options?.mutation?.onSuccess?.({}, variables);
+    },
     isPending: false,
   })),
 }));
@@ -115,13 +119,15 @@ vi.mock("@/components/features/movs/FileUpload", () => ({
   ),
 }));
 
-const wrap = (ui: React.ReactNode) => {
-  const client = new QueryClient({
+const createTestQueryClient = () =>
+  new QueryClient({
     defaultOptions: {
       queries: { retry: false },
       mutations: { retry: false },
     },
   });
+
+const wrap = (ui: React.ReactNode, client = createTestQueryClient()) => {
   return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
 };
 
@@ -212,6 +218,7 @@ describe("MiddleMovFilesPanel", () => {
     vi.clearAllMocks();
     mockUploadMutate.mockReset();
     mockDeleteMutate.mockReset();
+    mockPatchFeedbackMutate.mockReset();
     isUploadPending = false;
   });
 
@@ -432,6 +439,52 @@ describe("MiddleMovFilesPanel", () => {
     expect(
       screen.queryByRole("button", { name: /view barangay upload history/i })
     ).not.toBeInTheDocument();
+  });
+
+  it("patches cached assessment MOV feedback after validator feedback is saved", async () => {
+    const user = userEvent.setup();
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(useAuthStore).mockReturnValue({
+      user: { id: 42, role: "VALIDATOR" },
+    });
+    queryClient.setQueryData(["assessor-assessment", 1], assessment);
+
+    render(
+      wrap(<MiddleMovFilesPanel assessment={assessment as any} expandedId={101} />, queryClient)
+    );
+
+    await user.click(screen.getByRole("button", { name: /preview evidence\.png/i }));
+    await user.type(
+      screen.getByPlaceholderText(/describe the specific issue with this file/i),
+      "no signature"
+    );
+    await user.click(screen.getByRole("button", { name: /save feedback/i }));
+
+    expect(mockPatchFeedbackMutate).toHaveBeenCalledWith({
+      movFileId: 9,
+      data: {
+        assessor_notes: undefined,
+        flagged_for_rework: undefined,
+        validator_notes: "no signature",
+        flagged_for_calibration: true,
+      },
+    });
+    expect(queryClient.getQueryData<any>(["assessor-assessment", 1])).toMatchObject({
+      assessment: {
+        responses: [
+          {
+            movs: [
+              {
+                id: 9,
+                validator_notes: "no signature",
+                flagged_for_calibration: true,
+              },
+            ],
+          },
+        ],
+      },
+    });
   });
 
   it("lets validators remove only their own validator-uploaded files", async () => {

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -358,9 +358,11 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   // 3. Already has a validation status from database (PASS/FAIL/CONDITIONAL - e.g., after calibration), OR
   // 4. Validator has entered a comment/finding
   const isIndicatorReviewed = (responseId: number): boolean => {
+    const response = responses.find((r: AnyRecord) => r.id === responseId);
+
     return (
       hasChecklistItemsChecked(responseId) ||
-      calibrationFlags[responseId] === true ||
+      (response ? responseHasAttention(response) : calibrationFlags[responseId] === true) ||
       hasExistingValidationStatus(responseId) ||
       hasValidatorComment(responseId)
     );

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -324,6 +324,22 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     return !!(formData?.publicComment && formData.publicComment.trim().length > 0);
   };
 
+  const responseHasServerMovAttention = (response: AnyRecord): boolean => {
+    const movs = Array.isArray(response.movs) ? response.movs : [];
+
+    return movs.some((mov: AnyRecord) => {
+      const hasValidatorNotes = Boolean(
+        mov.validator_notes && String(mov.validator_notes).trim().length > 0
+      );
+
+      return hasValidatorNotes || mov.flagged_for_calibration === true;
+    });
+  };
+
+  const responseHasAttention = (response: AnyRecord): boolean => {
+    return responseHasServerMovAttention(response) || calibrationFlags[response.id] === true;
+  };
+
   // Helper: Check if an indicator is "reviewed"
   // An indicator is reviewed if:
   // 1. Has checklist items checked in current session, OR
@@ -369,6 +385,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
         name: indicator.name || "Unnamed Indicator",
         // For validators: Show completed if checklist items checked OR flagged for calibration
         status: isIndicatorReviewed(resp.id) ? "completed" : "not_started",
+        hasMovNotes: responseHasAttention(resp),
       });
 
       // Sort indicators by code after adding
@@ -1016,6 +1033,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                   assessment={transformedAssessment as any}
                   selectedIndicatorId={selectedIndicatorId}
                   onIndicatorSelect={handleIndicatorSelect}
+                  movAttentionVariant="danger"
                 />
               </div>
             )}
@@ -1071,6 +1089,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                   assessment={transformedAssessment as any}
                   selectedIndicatorId={selectedIndicatorId}
                   onIndicatorSelect={handleIndicatorSelect}
+                  movAttentionVariant="danger"
                 />
               </div>
             </div>
@@ -1163,6 +1182,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                   assessment={transformedAssessment as any}
                   selectedIndicatorId={selectedIndicatorId}
                   onIndicatorSelect={handleIndicatorSelect}
+                  movAttentionVariant="danger"
                 />
               </div>
             </div>

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -29,7 +29,7 @@ import { ChevronLeft, ClipboardCheck } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { MiddleMovFilesPanel } from "../assessor/validation/MiddleMovFilesPanel";
 
@@ -97,6 +97,9 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   const [checklistState, setChecklistState] = useState<Record<string, any>>({});
   // Store calibration flag state (which indicators are flagged for calibration)
   const [calibrationFlags, setCalibrationFlags] = useState<Record<number, boolean>>({});
+  const [movAttentionByResponse, setMovAttentionByResponse] = useState<
+    Record<number, Record<number, boolean>>
+  >({});
   const [draftSaveState, setDraftSaveState] = useState<DraftSaveState>("idle");
   const [completedAutosaveCount, setCompletedAutosaveCount] = useState(0);
   const [dirtyResponseIds, setDirtyResponseIds] = useState<number[]>([]);
@@ -337,7 +340,15 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   };
 
   const responseHasAttention = (response: AnyRecord): boolean => {
-    return responseHasServerMovAttention(response) || calibrationFlags[response.id] === true;
+    const localFileAttention = Object.values(movAttentionByResponse[response.id] ?? {}).some(
+      Boolean
+    );
+
+    return (
+      responseHasServerMovAttention(response) ||
+      localFileAttention ||
+      calibrationFlags[response.id] === true
+    );
   };
 
   // Helper: Check if an indicator is "reviewed"
@@ -898,6 +909,19 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     }, 0);
   };
 
+  const handleMovAttentionChange = useCallback(
+    (responseId: number, movFileId: number, hasAttention: boolean) => {
+      setMovAttentionByResponse((prev) => ({
+        ...prev,
+        [responseId]: {
+          ...(prev[responseId] ?? {}),
+          [movFileId]: hasAttention,
+        },
+      }));
+    },
+    []
+  );
+
   if (isLoading) {
     return (
       <div className="mx-auto max-w-7xl px-6 py-10 text-sm text-muted-foreground">
@@ -1058,6 +1082,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                       handleCalibrationFlagChange(responseId, false);
                     }
                   }}
+                  onMovAttentionChange={handleMovAttentionChange}
                 />
               </div>
             )}
@@ -1149,6 +1174,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                           handleCalibrationFlagChange(responseId, false);
                         }
                       }}
+                      onMovAttentionChange={handleMovAttentionChange}
                     />
                   </div>
                 )}
@@ -1208,6 +1234,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                     handleCalibrationFlagChange(responseId, false);
                   }
                 }}
+                onMovAttentionChange={handleMovAttentionChange}
               />
             </div>
 

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -82,7 +82,22 @@ vi.mock("../../assessor/validation/MiddleMovFilesPanel", () => ({
 }));
 
 vi.mock("@/components/features/assessments/tree-navigation", () => ({
-  TreeNavigator: () => <div data-testid="tree-nav" />,
+  TreeNavigator: ({ assessment }: any) => (
+    <div data-testid="tree-nav">
+      {assessment.governanceAreas.flatMap((area: any) =>
+        area.indicators.map((indicator: any) => (
+          <div
+            key={indicator.id}
+            data-testid={`tree-indicator-${indicator.id}`}
+            data-has-mov-notes={String(Boolean(indicator.hasMovNotes))}
+            data-status={indicator.status}
+          >
+            {indicator.code}
+          </div>
+        ))
+      )}
+    </div>
+  ),
 }));
 
 vi.mock("sonner", () => ({
@@ -125,7 +140,16 @@ function wrap(ui: React.ReactNode) {
   return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
 }
 
-function makeAssessment() {
+function expectSidebarAttention(responseId: number, hasAttention: boolean) {
+  const indicators = screen.getAllByTestId(`tree-indicator-${responseId}`);
+
+  expect(indicators.length).toBeGreaterThan(0);
+  indicators.forEach((indicator) => {
+    expect(indicator).toHaveAttribute("data-has-mov-notes", String(hasAttention));
+  });
+}
+
+function makeAssessment(responseOverrides: Record<string, any> = {}) {
   return {
     success: true,
     assessment_id: 1,
@@ -154,6 +178,7 @@ function makeAssessment() {
           feedback_comments: [],
           validation_status: "PASS",
           flagged_for_calibration: false,
+          ...responseOverrides,
         },
       ],
     },
@@ -289,5 +314,49 @@ describe("ValidatorValidationClient autosave", () => {
     }).not.toThrow();
 
     expect(screen.getByText(/loading assessment/i)).toBeInTheDocument();
+  });
+
+  it("marks a validator sidebar indicator as needing attention when a MOV has validator notes", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment({
+        movs: [
+          {
+            id: 1,
+            uploaded_at: "2024-01-01T00:00:00Z",
+            validator_notes: "no signature",
+            flagged_for_calibration: false,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    expectSidebarAttention(201, true);
+  });
+
+  it("marks a validator sidebar indicator as needing attention when a MOV is flagged for calibration", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment({
+        movs: [
+          {
+            id: 1,
+            uploaded_at: "2024-01-01T00:00:00Z",
+            validator_notes: "",
+            flagged_for_calibration: true,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    expectSidebarAttention(201, true);
   });
 });

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -347,6 +347,32 @@ describe("ValidatorValidationClient autosave", () => {
     expectSidebarAttention(201, true);
   });
 
+  it("counts a saved validator MOV note as reviewed even without a validation status", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment({
+        validation_status: null,
+        movs: [
+          {
+            id: 1,
+            uploaded_at: "2024-01-01T00:00:00Z",
+            validator_notes: "no signature",
+            flagged_for_calibration: false,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    screen.getAllByTestId("tree-indicator-201").forEach((indicator) => {
+      expect(indicator).toHaveAttribute("data-has-mov-notes", "true");
+      expect(indicator).toHaveAttribute("data-status", "completed");
+    });
+  });
+
   it("marks a validator sidebar indicator as needing attention when a MOV is flagged for calibration", () => {
     mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
       data: makeAssessment({

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -78,7 +78,16 @@ vi.mock("next/dynamic", () => ({
 }));
 
 vi.mock("../../assessor/validation/MiddleMovFilesPanel", () => ({
-  MiddleMovFilesPanel: () => <div data-testid="mov-panel" />,
+  MiddleMovFilesPanel: (props: any) => (
+    <div data-testid="mov-panel">
+      <button onClick={() => props.onMovAttentionChange?.(201, 1, true)}>
+        Add validator MOV note
+      </button>
+      <button onClick={() => props.onMovAttentionChange?.(201, 1, false)}>
+        Clear validator MOV note
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("@/components/features/assessments/tree-navigation", () => ({
@@ -356,6 +365,63 @@ describe("ValidatorValidationClient autosave", () => {
     });
 
     render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    expectSidebarAttention(201, true);
+  });
+
+  it("updates the validator sidebar warning state immediately when a MOV note is added locally", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    expectSidebarAttention(201, false);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Add validator MOV note" })[0]);
+
+    expectSidebarAttention(201, true);
+  });
+
+  it("clears the validator sidebar warning state when the only local MOV attention is removed", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Add validator MOV note" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Clear validator MOV note" })[0]);
+
+    expectSidebarAttention(201, false);
+  });
+
+  it("keeps saved server MOV attention after a local override is cleared", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment({
+        movs: [
+          {
+            id: 1,
+            uploaded_at: "2024-01-01T00:00:00Z",
+            validator_notes: "saved note",
+            flagged_for_calibration: false,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Clear validator MOV note" })[0]);
 
     expectSidebarAttention(201, true);
   });

--- a/packages/shared/src/generated/schemas/assessor/index.ts
+++ b/packages/shared/src/generated/schemas/assessor/index.ts
@@ -66,6 +66,10 @@ export interface AssessorProgressItem {
   assessor_id: AssessorProgressItemAssessorId;
   assessor_name: AssessorProgressItemAssessorName;
   status: string;
+  /** @minimum 0 */
+  reviewed_indicators?: number;
+  /** @minimum 0 */
+  total_indicators?: number;
   /**
    * @minimum 0
    * @maximum 100


### PR DESCRIPTION
-  allow validators to upload and delete validator-owned MOVs during final validation and calibration rework
- surface validator MOV notes and calibration flags as red sidebar attention indicators
- prioritize validator-uploaded files above barangay evidence in the MOV file panel
- update MLGOO assessment progress to use explicit assessor reviewed/total counts
- fix re-review progress after rework, calibration, and MLGOO recalibration resubmission timestamps
- regenerate shared assessor schema types for new progress fields
- add backend and frontend coverage for progress, MOV feedback cache updates, and sidebar warning states
