### PR TITLE
fix(validator): correct post-calibration progress icons

### DIFF
--- a/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
+++ b/apps/web/src/components/features/assessor/validation/MiddleMovFilesPanel.tsx
@@ -3,6 +3,11 @@
 
 import { FileList } from "@/components/features/movs/FileList";
 import { FileUpload } from "@/components/features/movs/FileUpload";
+import {
+  hasValidatorFileFeedback,
+  isBlguEvidenceFile,
+  isSupersededBlguMovFile,
+} from "@/components/features/validator/validator-progress";
 import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -71,18 +76,6 @@ function hasAssessorFileFeedback(file: AnyRecord): boolean {
   );
 }
 
-function hasValidatorFileFeedback(file: AnyRecord): boolean {
-  return (
-    Boolean(file.validator_notes && String(file.validator_notes).trim()) ||
-    file.flagged_for_calibration === true
-  );
-}
-
-function getUploadedAtMs(file: AnyRecord): number {
-  const timestamp = file.uploaded_at ? new Date(String(file.uploaded_at)).getTime() : 0;
-  return Number.isFinite(timestamp) ? timestamp : 0;
-}
-
 function groupValidatorFilesForDisplay(files: (MOVFileResponse & AnyRecord)[]): {
   newFiles: (MOVFileResponse & AnyRecord)[];
   acceptedOldFiles: (MOVFileResponse & AnyRecord)[];
@@ -93,22 +86,23 @@ function groupValidatorFilesForDisplay(files: (MOVFileResponse & AnyRecord)[]): 
   const rejectedOldFiles: (MOVFileResponse & AnyRecord)[] = [];
 
   for (const file of files) {
-    const uploadedAt = getUploadedAtMs(file);
-    const hasNewerUpload = files.some((candidate) => getUploadedAtMs(candidate) > uploadedAt);
-    const hasAssessorFeedback = hasAssessorFileFeedback(file);
-    const hasValidatorFeedback = hasValidatorFileFeedback(file);
-
-    if (hasValidatorFeedback) {
-      if (hasNewerUpload) {
-        rejectedOldFiles.push(file);
-      } else {
-        acceptedOldFiles.push(file);
-      }
+    if (!isBlguEvidenceFile(file)) {
+      acceptedOldFiles.push(file);
       continue;
     }
 
-    if (hasAssessorFeedback) {
-      rejectedOldFiles.push(file);
+    const superseded = isSupersededBlguMovFile(file, files);
+    const hasAssessorFeedback = hasAssessorFileFeedback(file);
+    const hasValidatorFeedback = hasValidatorFileFeedback(file);
+
+    if (hasValidatorFeedback || hasAssessorFeedback) {
+      if (superseded) {
+        rejectedOldFiles.push(file);
+      } else if (hasValidatorFeedback) {
+        acceptedOldFiles.push(file);
+      } else {
+        rejectedOldFiles.push(file);
+      }
       continue;
     }
 

--- a/apps/web/src/components/features/assessor/validation/__tests__/MiddleMovFilesPanel.grouping.test.tsx
+++ b/apps/web/src/components/features/assessor/validation/__tests__/MiddleMovFilesPanel.grouping.test.tsx
@@ -269,6 +269,141 @@ describe("MiddleMovFilesPanel MOV grouping in validator mode", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("moves an older flagged BLGU file to previous history when replaced in the same field", () => {
+    const assessment = buildAssessment([
+      {
+        id: 1,
+        filename: "old-ordinance.pdf",
+        original_filename: "old-ordinance.pdf",
+        file_size: 100,
+        content_type: "application/pdf",
+        storage_path: "/old-ordinance",
+        field_id: "ordinance",
+        uploaded_at: "2026-03-01T10:00:00Z",
+        upload_origin: "blgu",
+        validator_notes: "missing signature",
+        flagged_for_calibration: true,
+      },
+      {
+        id: 2,
+        filename: "new-ordinance.pdf",
+        original_filename: "new-ordinance.pdf",
+        file_size: 100,
+        content_type: "application/pdf",
+        storage_path: "/new-ordinance",
+        field_id: "ordinance",
+        uploaded_at: "2026-03-12T10:00:00Z",
+        upload_origin: "blgu",
+      },
+    ]);
+
+    render(
+      wrap(
+        <MiddleMovFilesPanel
+          assessment={assessment}
+          expandedId={101}
+          calibrationRequestedAt="2026-03-10T10:00:00Z"
+        />
+      )
+    );
+
+    const latestSection = getSectionContainer("Latest File (After Calibration)");
+    const previousSection = getSectionContainer("Previous File");
+
+    expect(within(latestSection).getByText("new-ordinance.pdf")).toBeInTheDocument();
+    expect(within(previousSection).getByText("old-ordinance.pdf")).toBeInTheDocument();
+  });
+
+  it("keeps an older flagged BLGU file active when the newer BLGU upload is a different field", () => {
+    const assessment = buildAssessment([
+      {
+        id: 1,
+        filename: "old-ordinance.pdf",
+        original_filename: "old-ordinance.pdf",
+        file_size: 100,
+        content_type: "application/pdf",
+        storage_path: "/old-ordinance",
+        field_id: "ordinance",
+        uploaded_at: "2026-03-01T10:00:00Z",
+        upload_origin: "blgu",
+        validator_notes: "missing signature",
+        flagged_for_calibration: true,
+      },
+      {
+        id: 2,
+        filename: "new-attendance.pdf",
+        original_filename: "new-attendance.pdf",
+        file_size: 100,
+        content_type: "application/pdf",
+        storage_path: "/new-attendance",
+        field_id: "attendance",
+        uploaded_at: "2026-03-12T10:00:00Z",
+        upload_origin: "blgu",
+      },
+    ]);
+
+    render(
+      wrap(
+        <MiddleMovFilesPanel
+          assessment={assessment}
+          expandedId={101}
+          calibrationRequestedAt="2026-03-10T10:00:00Z"
+        />
+      )
+    );
+
+    const existingSection = getSectionContainer("Existing File");
+    const latestSection = getSectionContainer("Latest File (After Calibration)");
+
+    expect(within(existingSection).getByText("old-ordinance.pdf")).toBeInTheDocument();
+    expect(within(latestSection).getByText("new-attendance.pdf")).toBeInTheDocument();
+  });
+
+  it("keeps an older flagged BLGU file active when the newer same-field upload is from a validator", () => {
+    const assessment = buildAssessment([
+      {
+        id: 1,
+        filename: "old-ordinance.pdf",
+        original_filename: "old-ordinance.pdf",
+        file_size: 100,
+        content_type: "application/pdf",
+        storage_path: "/old-ordinance",
+        field_id: "ordinance",
+        uploaded_at: "2026-03-01T10:00:00Z",
+        upload_origin: "blgu",
+        validator_notes: "missing signature",
+        flagged_for_calibration: true,
+      },
+      {
+        id: 2,
+        filename: "validator-ordinance.pdf",
+        original_filename: "validator-ordinance.pdf",
+        file_size: 100,
+        content_type: "application/pdf",
+        storage_path: "/validator-ordinance",
+        field_id: "ordinance",
+        uploaded_at: "2026-03-12T10:00:00Z",
+        upload_origin: "validator",
+      },
+    ]);
+
+    render(
+      wrap(
+        <MiddleMovFilesPanel
+          assessment={assessment}
+          expandedId={101}
+          calibrationRequestedAt="2026-03-10T10:00:00Z"
+        />
+      )
+    );
+
+    const existingSection = getSectionContainer("Existing File");
+    const validatorSection = getSectionContainer("Validator Uploads");
+
+    expect(within(existingSection).getByText("old-ordinance.pdf")).toBeInTheDocument();
+    expect(within(validatorSection).getByText("validator-ordinance.pdf")).toBeInTheDocument();
+  });
+
   it("shows validator uploads in a separate provenance section", () => {
     const assessment = buildAssessment([
       {

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -32,6 +32,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { MiddleMovFilesPanel } from "../assessor/validation/MiddleMovFilesPanel";
+import { getValidatorIndicatorProgress, hasExistingValidationStatus } from "./validator-progress";
 
 // Lazy load heavy RightAssessorPanel component (1400+ LOC)
 const RightAssessorPanel = dynamic(
@@ -298,80 +299,26 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   const reworkRequestedAt: string | null = (core?.rework_requested_at ?? null) as string | null;
   // Default label (MiddleMovFilesPanel will override based on indicator context)
   const separationLabel = calibrationRequestedAt ? "After Calibration" : "After Rework";
+  const isPostCalibrationReview = Boolean(calibrationRequestedAt);
 
   useEffect(() => {
     responsesRef.current = responses;
   }, [responses]);
 
-  // Helper: Check if a response has any checklist items checked by the validator
-  const hasChecklistItemsChecked = (responseId: number): boolean => {
-    return Object.keys(checklistState).some(
-      (key) => key.startsWith(`checklist_${responseId}_`) && checklistState[key] === true
-    );
-  };
-
-  // Helper: Check if a response already has a validation status from database
-  const hasExistingValidationStatus = (responseId: number): boolean => {
-    const response = responses.find((r: any) => r.id === responseId);
-    if (!response) return false;
-    const status = (response as any).validation_status;
-    // Check if status is PASS, FAIL, or CONDITIONAL (case-insensitive)
-    if (!status) return false;
-    const statusUpper = String(status).toUpperCase();
-    return statusUpper === "PASS" || statusUpper === "FAIL" || statusUpper === "CONDITIONAL";
-  };
-
-  // Helper: Check if validator has entered a comment/finding for this response
-  const hasValidatorComment = (responseId: number): boolean => {
-    const formData = form[responseId];
-    return !!(formData?.publicComment && formData.publicComment.trim().length > 0);
-  };
-
-  const responseHasServerMovAttention = (response: AnyRecord): boolean => {
-    const movs = Array.isArray(response.movs) ? response.movs : [];
-
-    return movs.some((mov: AnyRecord) => {
-      const hasValidatorNotes = Boolean(
-        mov.validator_notes && String(mov.validator_notes).trim().length > 0
-      );
-
-      return hasValidatorNotes || mov.flagged_for_calibration === true;
+  const getProgressForResponse = (response: AnyRecord) =>
+    getValidatorIndicatorProgress(response, {
+      checklistState,
+      localMovAttentionByFileId: movAttentionByResponse[response.id] ?? {},
+      responseCalibrationFlag: calibrationFlags[response.id] === true,
+      strictChecklistRequired: isPostCalibrationReview,
     });
-  };
-
-  const responseHasAttention = (response: AnyRecord): boolean => {
-    const localFileAttention = Object.values(movAttentionByResponse[response.id] ?? {}).some(
-      Boolean
-    );
-
-    return (
-      responseHasServerMovAttention(response) ||
-      localFileAttention ||
-      calibrationFlags[response.id] === true
-    );
-  };
-
-  // Helper: Check if an indicator is "reviewed"
-  // An indicator is reviewed if:
-  // 1. Has checklist items checked in current session, OR
-  // 2. Flagged for calibration, OR
-  // 3. Already has a validation status from database (PASS/FAIL/CONDITIONAL - e.g., after calibration), OR
-  // 4. Validator has entered a comment/finding
-  const isIndicatorReviewed = (responseId: number): boolean => {
-    const response = responses.find((r: AnyRecord) => r.id === responseId);
-
-    return (
-      hasChecklistItemsChecked(responseId) ||
-      (response ? responseHasAttention(response) : calibrationFlags[responseId] === true) ||
-      hasExistingValidationStatus(responseId) ||
-      hasValidatorComment(responseId)
-    );
-  };
 
   // Transform to match BLGU assessment structure for TreeNavigator
   const transformedAssessment = {
     id: assessmentId,
-    completedIndicators: responses.filter((r: any) => isIndicatorReviewed(r.id)).length,
+    completedIndicators: responses.filter(
+      (r: AnyRecord) => getProgressForResponse(r).status === "completed"
+    ).length,
     totalIndicators: responses.length,
     governanceAreas: responses.reduce((acc: any[], resp: any) => {
       const indicator = resp.indicator || {};
@@ -396,9 +343,8 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
         id: String(resp.id),
         code: indicator.indicator_code || indicator.code || String(resp.id),
         name: indicator.name || "Unnamed Indicator",
-        // For validators: Show completed if checklist items checked OR flagged for calibration
-        status: isIndicatorReviewed(resp.id) ? "completed" : "not_started",
-        hasMovNotes: responseHasAttention(resp),
+        status: getProgressForResponse(resp).status,
+        hasMovNotes: getProgressForResponse(resp).hasMovNotes,
       });
 
       // Sort indicators by code after adding
@@ -409,15 +355,12 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   };
 
   const total = responses.length;
-  // For validators: "reviewed" means checklist items checked OR flagged for calibration
-  const reviewed = responses.filter((r) => isIndicatorReviewed(r.id as number)).length;
+  const reviewed = responses.filter((r) => getProgressForResponse(r).status === "completed").length;
   const progressPct = total > 0 ? Math.round((reviewed / total) * 100) : 0;
 
   // Check if ALL responses have validation_status confirmed (via Compliance Overview)
   // This is required before finalization - validators must confirm each indicator status
-  const confirmedCount = responses.filter((r) =>
-    hasExistingValidationStatus(r.id as number)
-  ).length;
+  const confirmedCount = responses.filter((r) => hasExistingValidationStatus(r)).length;
   const allConfirmed = total > 0 && confirmedCount === total;
 
   const getResponseSnapshot = (responseId: number): string => {

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -309,7 +309,6 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     getValidatorIndicatorProgress(response, {
       checklistState,
       localMovAttentionByFileId: movAttentionByResponse[response.id] ?? {},
-      responseCalibrationFlag: calibrationFlags[response.id] === true,
       strictChecklistRequired: isPostCalibrationReview,
     });
 

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -487,7 +487,8 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
       return saveResponses(remainingResponseIds, options);
     }
 
-    const savePromise = (async () => {
+    let savePromise!: Promise<boolean>;
+    savePromise = (async () => {
       isSavingRef.current = true;
       setDraftSaveState("saving");
       let savedPayloadCount = 0;

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -462,6 +462,7 @@ describe("ValidatorValidationClient autosave", () => {
     mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
       data: makeAssessment(
         {
+          flagged_for_calibration: true,
           validation_status: "PASS",
           response_data: {
             validator_val_requirement_1: true,

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -158,7 +158,10 @@ function expectSidebarAttention(responseId: number, hasAttention: boolean) {
   });
 }
 
-function makeAssessment(responseOverrides: Record<string, any> = {}) {
+function makeAssessment(
+  responseOverrides: Record<string, any> = {},
+  assessmentOverrides: Record<string, any> = {}
+) {
   return {
     success: true,
     assessment_id: 1,
@@ -172,6 +175,7 @@ function makeAssessment(responseOverrides: Record<string, any> = {}) {
         barangay: { id: 1, name: "Test Barangay" },
       },
       calibrated_area_ids: [],
+      ...assessmentOverrides,
       responses: [
         {
           id: 201,
@@ -181,6 +185,8 @@ function makeAssessment(responseOverrides: Record<string, any> = {}) {
             name: "Test Indicator",
             indicator_code: "2.1.1",
             governance_area: { id: 2, name: "Disaster Preparedness" },
+            checklist_items: [{ item_id: "requirement_1", item_type: "checkbox", required: true }],
+            validation_rule: "ALL_ITEMS_REQUIRED",
           },
           movs: [{ id: 1, uploaded_at: "2024-01-01T00:00:00Z" }],
           response_data: {},
@@ -450,5 +456,89 @@ describe("ValidatorValidationClient autosave", () => {
     fireEvent.click(screen.getAllByRole("button", { name: "Clear validator MOV note" })[0]);
 
     expectSidebarAttention(201, true);
+  });
+
+  it("shows completed sidebar state after post-calibration same-field replacement files are clean", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(
+        {
+          validation_status: "PASS",
+          response_data: {
+            validator_val_requirement_1: true,
+          },
+          movs: [
+            {
+              id: 1,
+              field_id: "ordinance",
+              uploaded_at: "2026-03-01T00:00:00.000Z",
+              upload_origin: "blgu",
+              validator_notes: "missing signature",
+              flagged_for_calibration: true,
+            },
+            {
+              id: 2,
+              field_id: "ordinance",
+              uploaded_at: "2026-04-01T00:00:00.000Z",
+              upload_origin: "blgu",
+              validator_notes: "",
+              flagged_for_calibration: false,
+            },
+          ],
+        },
+        { calibration_requested_at: "2026-03-15T00:00:00.000Z" }
+      ),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    screen.getAllByTestId("tree-indicator-201").forEach((indicator) => {
+      expect(indicator).toHaveAttribute("data-status", "completed");
+      expect(indicator).toHaveAttribute("data-has-mov-notes", "false");
+    });
+  });
+
+  it("keeps sidebar attention when a flagged existing file is not superseded by a different field", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(
+        {
+          validation_status: "PASS",
+          response_data: {
+            validator_val_requirement_1: true,
+          },
+          movs: [
+            {
+              id: 1,
+              field_id: "ordinance",
+              uploaded_at: "2026-03-01T00:00:00.000Z",
+              upload_origin: "blgu",
+              validator_notes: "missing signature",
+              flagged_for_calibration: true,
+            },
+            {
+              id: 2,
+              field_id: "attendance",
+              uploaded_at: "2026-04-01T00:00:00.000Z",
+              upload_origin: "blgu",
+              validator_notes: "",
+              flagged_for_calibration: false,
+            },
+          ],
+        },
+        { calibration_requested_at: "2026-03-15T00:00:00.000Z" }
+      ),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    screen.getAllByTestId("tree-indicator-201").forEach((indicator) => {
+      expect(indicator).toHaveAttribute("data-status", "completed");
+      expect(indicator).toHaveAttribute("data-has-mov-notes", "true");
+    });
   });
 });

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -537,7 +537,7 @@ describe("ValidatorValidationClient autosave", () => {
     render(wrap(<ValidatorValidationClient assessmentId={1} />));
 
     screen.getAllByTestId("tree-indicator-201").forEach((indicator) => {
-      expect(indicator).toHaveAttribute("data-status", "completed");
+      expect(indicator).toHaveAttribute("data-status", "not_started");
       expect(indicator).toHaveAttribute("data-has-mov-notes", "true");
     });
   });

--- a/apps/web/src/components/features/validator/__tests__/validator-progress.test.ts
+++ b/apps/web/src/components/features/validator/__tests__/validator-progress.test.ts
@@ -186,6 +186,28 @@ describe("validator-progress", () => {
     ).toEqual({ status: "completed", hasMovNotes: false });
   });
 
+  it("does not count strict post-calibration progress as complete while active BLGU files need attention", () => {
+    expect(
+      getValidatorIndicatorProgress(
+        response({
+          movs: [
+            mov({
+              id: 1,
+              validator_notes: "missing signature",
+              flagged_for_calibration: true,
+            }),
+          ],
+        }),
+        {
+          checklistState: { checklist_201_requirement_1: true },
+          localMovAttentionByFileId: {},
+          responseCalibrationFlag: false,
+          strictChecklistRequired: true,
+        }
+      )
+    ).toEqual({ status: "not_started", hasMovNotes: true });
+  });
+
   it("does not turn green from validation_status alone in strict post-calibration mode", () => {
     expect(
       getValidatorIndicatorProgress(response({ validation_status: "PASS" }), {

--- a/apps/web/src/components/features/validator/__tests__/validator-progress.test.ts
+++ b/apps/web/src/components/features/validator/__tests__/validator-progress.test.ts
@@ -180,7 +180,6 @@ describe("validator-progress", () => {
       getValidatorIndicatorProgress(response(), {
         checklistState: { checklist_201_requirement_1: true },
         localMovAttentionByFileId: {},
-        responseCalibrationFlag: false,
         strictChecklistRequired: true,
       })
     ).toEqual({ status: "completed", hasMovNotes: false });
@@ -201,11 +200,33 @@ describe("validator-progress", () => {
         {
           checklistState: { checklist_201_requirement_1: true },
           localMovAttentionByFileId: {},
-          responseCalibrationFlag: false,
           strictChecklistRequired: true,
         }
       )
     ).toEqual({ status: "not_started", hasMovNotes: true });
+  });
+
+  it("does not keep strict post-calibration attention from a stale response-level flag when same-field BLGU files are clean", () => {
+    const oldFile = mov({
+      id: 1,
+      field_id: "ordinance",
+      uploaded_at: "2026-03-01T00:00:00.000Z",
+      validator_notes: "missing signature",
+      flagged_for_calibration: true,
+    });
+    const replacement = mov({
+      id: 2,
+      field_id: "ordinance",
+      uploaded_at: "2026-04-01T00:00:00.000Z",
+    });
+
+    expect(
+      getValidatorIndicatorProgress(response({ movs: [oldFile, replacement] }), {
+        checklistState: { checklist_201_requirement_1: true },
+        localMovAttentionByFileId: {},
+        strictChecklistRequired: true,
+      })
+    ).toEqual({ status: "completed", hasMovNotes: false });
   });
 
   it("does not turn green from validation_status alone in strict post-calibration mode", () => {
@@ -213,7 +234,6 @@ describe("validator-progress", () => {
       getValidatorIndicatorProgress(response({ validation_status: "PASS" }), {
         checklistState: {},
         localMovAttentionByFileId: {},
-        responseCalibrationFlag: false,
         strictChecklistRequired: true,
       })
     ).toEqual({ status: "not_started", hasMovNotes: false });
@@ -224,7 +244,6 @@ describe("validator-progress", () => {
       getValidatorIndicatorProgress(response({ validation_status: "PASS" }), {
         checklistState: {},
         localMovAttentionByFileId: {},
-        responseCalibrationFlag: false,
         strictChecklistRequired: false,
       })
     ).toEqual({ status: "completed", hasMovNotes: false });

--- a/apps/web/src/components/features/validator/__tests__/validator-progress.test.ts
+++ b/apps/web/src/components/features/validator/__tests__/validator-progress.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import {
+  getValidatorChecklistCompletion,
+  getValidatorIndicatorProgress,
+  hasActiveValidatorMovAttention,
+  isSupersededBlguMovFile,
+} from "../validator-progress";
+
+function mov(overrides: Record<string, any> = {}) {
+  return {
+    id: 1,
+    field_id: "ordinance",
+    uploaded_at: "2026-04-01T00:00:00.000Z",
+    upload_origin: "blgu",
+    validator_notes: "",
+    flagged_for_calibration: false,
+    ...overrides,
+  };
+}
+
+function response(overrides: Record<string, any> = {}) {
+  return {
+    id: 201,
+    validation_status: null,
+    response_data: {},
+    flagged_for_calibration: false,
+    feedback_comments: [],
+    movs: [],
+    indicator: {
+      checklist_items: [{ item_id: "requirement_1", item_type: "checkbox", required: true }],
+      validation_rule: "ALL_ITEMS_REQUIRED",
+    },
+    ...overrides,
+  };
+}
+
+describe("validator-progress", () => {
+  it("requires all required validator checklist items for ALL_ITEMS_REQUIRED", () => {
+    const itemResponse = response({
+      indicator: {
+        checklist_items: [
+          { item_id: "requirement_1", item_type: "checkbox", required: true },
+          { item_id: "requirement_2", item_type: "checkbox", required: true },
+        ],
+        validation_rule: "ALL_ITEMS_REQUIRED",
+      },
+    });
+
+    expect(
+      getValidatorChecklistCompletion(itemResponse, {
+        checklist_201_requirement_1: true,
+      }).isComplete
+    ).toBe(false);
+
+    expect(
+      getValidatorChecklistCompletion(itemResponse, {
+        checklist_201_requirement_1: true,
+        checklist_201_requirement_2: true,
+      }).isComplete
+    ).toBe(true);
+  });
+
+  it("supports option groups using the same completion shape as RightAssessorPanel", () => {
+    const groupedResponse = response({
+      indicator: {
+        checklist_items: [
+          { item_id: "base", item_type: "checkbox", required: true },
+          { item_id: "a1", item_type: "checkbox", option_group: "Option 1" },
+          { item_id: "a2", item_type: "checkbox", option_group: "Option 1" },
+          { item_id: "b1", item_type: "checkbox", option_group: "Option 2" },
+        ],
+        validation_rule: "ALL_ITEMS_REQUIRED",
+      },
+    });
+
+    expect(
+      getValidatorChecklistCompletion(groupedResponse, {
+        checklist_201_base: true,
+        checklist_201_a1: true,
+      }).isComplete
+    ).toBe(false);
+
+    expect(
+      getValidatorChecklistCompletion(groupedResponse, {
+        checklist_201_base: true,
+        checklist_201_a1: true,
+        checklist_201_a2: true,
+      }).isComplete
+    ).toBe(true);
+  });
+
+  it("only supersedes old BLGU files with newer BLGU files from the same field", () => {
+    const oldOrdinance = mov({
+      id: 1,
+      field_id: "ordinance",
+      uploaded_at: "2026-03-01T00:00:00.000Z",
+      validator_notes: "missing signature",
+      flagged_for_calibration: true,
+    });
+    const newAttendance = mov({
+      id: 2,
+      field_id: "attendance",
+      uploaded_at: "2026-04-01T00:00:00.000Z",
+    });
+
+    expect(isSupersededBlguMovFile(oldOrdinance, [oldOrdinance, newAttendance])).toBe(false);
+  });
+
+  it("supersedes an old BLGU file with a newer BLGU file from the same field", () => {
+    const oldFile = mov({
+      id: 1,
+      field_id: "ordinance",
+      uploaded_at: "2026-03-01T00:00:00.000Z",
+      validator_notes: "missing signature",
+      flagged_for_calibration: true,
+    });
+    const replacement = mov({
+      id: 2,
+      field_id: "ordinance",
+      uploaded_at: "2026-04-01T00:00:00.000Z",
+    });
+
+    expect(isSupersededBlguMovFile(oldFile, [oldFile, replacement])).toBe(true);
+    expect(
+      hasActiveValidatorMovAttention(response({ movs: [oldFile, replacement] }), {
+        localMovAttentionByFileId: {},
+      })
+    ).toBe(false);
+  });
+
+  it("does not let validator-uploaded files supersede BLGU files", () => {
+    const oldFile = mov({
+      id: 1,
+      field_id: "ordinance",
+      uploaded_at: "2026-03-01T00:00:00.000Z",
+      flagged_for_calibration: true,
+    });
+    const validatorUpload = mov({
+      id: 2,
+      field_id: "ordinance",
+      uploaded_at: "2026-04-01T00:00:00.000Z",
+      upload_origin: "validator",
+    });
+
+    expect(isSupersededBlguMovFile(oldFile, [oldFile, validatorUpload])).toBe(false);
+    expect(
+      hasActiveValidatorMovAttention(response({ movs: [oldFile, validatorUpload] }), {
+        localMovAttentionByFileId: {},
+      })
+    ).toBe(true);
+  });
+
+  it("evaluates local unsaved MOV attention by active file id", () => {
+    const oldFile = mov({
+      id: 1,
+      field_id: "ordinance",
+      uploaded_at: "2026-03-01T00:00:00.000Z",
+    });
+    const replacement = mov({
+      id: 2,
+      field_id: "ordinance",
+      uploaded_at: "2026-04-01T00:00:00.000Z",
+    });
+
+    expect(
+      hasActiveValidatorMovAttention(response({ movs: [oldFile, replacement] }), {
+        localMovAttentionByFileId: { 1: true },
+      })
+    ).toBe(false);
+
+    expect(
+      hasActiveValidatorMovAttention(response({ movs: [oldFile, replacement] }), {
+        localMovAttentionByFileId: { 2: true },
+      })
+    ).toBe(true);
+  });
+
+  it("turns green only when checklist is complete and active BLGU files are clean", () => {
+    expect(
+      getValidatorIndicatorProgress(response(), {
+        checklistState: { checklist_201_requirement_1: true },
+        localMovAttentionByFileId: {},
+        responseCalibrationFlag: false,
+        strictChecklistRequired: true,
+      })
+    ).toEqual({ status: "completed", hasMovNotes: false });
+  });
+
+  it("does not turn green from validation_status alone in strict post-calibration mode", () => {
+    expect(
+      getValidatorIndicatorProgress(response({ validation_status: "PASS" }), {
+        checklistState: {},
+        localMovAttentionByFileId: {},
+        responseCalibrationFlag: false,
+        strictChecklistRequired: true,
+      })
+    ).toEqual({ status: "not_started", hasMovNotes: false });
+  });
+
+  it("preserves existing validation_status only when strict checklist mode is off", () => {
+    expect(
+      getValidatorIndicatorProgress(response({ validation_status: "PASS" }), {
+        checklistState: {},
+        localMovAttentionByFileId: {},
+        responseCalibrationFlag: false,
+        strictChecklistRequired: false,
+      })
+    ).toEqual({ status: "completed", hasMovNotes: false });
+  });
+});

--- a/apps/web/src/components/features/validator/validator-progress.ts
+++ b/apps/web/src/components/features/validator/validator-progress.ts
@@ -1,0 +1,195 @@
+type AnyRecord = Record<string, any>;
+
+export interface ValidatorProgressInput {
+  checklistState: Record<string, any>;
+  localMovAttentionByFileId: Record<number, boolean | undefined>;
+  responseCalibrationFlag: boolean;
+  strictChecklistRequired: boolean;
+}
+
+export interface ValidatorChecklistCompletion {
+  isComplete: boolean;
+  validatableItemCount: number;
+}
+
+export interface ValidatorIndicatorProgress {
+  status: "completed" | "not_started";
+  hasMovNotes: boolean;
+}
+
+function hasText(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function uploadedAtMs(file: AnyRecord): number {
+  const time = file.uploaded_at ? new Date(String(file.uploaded_at)).getTime() : 0;
+  return Number.isFinite(time) ? time : 0;
+}
+
+function getFieldKey(file: AnyRecord): string {
+  return String(file.field_id ?? "__missing_field__");
+}
+
+export function isBlguEvidenceFile(file: AnyRecord): boolean {
+  return file.upload_origin !== "validator";
+}
+
+export function hasValidatorFileFeedback(file: AnyRecord): boolean {
+  return hasText(file.validator_notes) || file.flagged_for_calibration === true;
+}
+
+export function isSupersededBlguMovFile(file: AnyRecord, files: AnyRecord[]): boolean {
+  if (!isBlguEvidenceFile(file)) return false;
+
+  const currentTime = uploadedAtMs(file);
+  const fieldKey = getFieldKey(file);
+
+  return files.some((candidate) => {
+    if (!isBlguEvidenceFile(candidate)) return false;
+    if (getFieldKey(candidate) !== fieldKey) return false;
+    return uploadedAtMs(candidate) > currentTime;
+  });
+}
+
+function isChecklistItemFilled(
+  responseId: number,
+  item: AnyRecord,
+  checklistState: Record<string, any>
+): boolean {
+  const itemKey = `checklist_${responseId}_${item.item_id}`;
+
+  if (
+    item.item_type === "document_count" ||
+    item.item_type === "calculation_field" ||
+    item.item_type === "date_input" ||
+    item.item_type === "text_input" ||
+    item.requires_document_count
+  ) {
+    const value = checklistState[itemKey];
+    return value !== false && value != null && String(value).trim() !== "";
+  }
+
+  if (item.item_type === "assessment_field") {
+    return checklistState[`${itemKey}_yes`] === true;
+  }
+
+  return checklistState[itemKey] === true;
+}
+
+export function getValidatorChecklistCompletion(
+  response: AnyRecord,
+  checklistState: Record<string, any>
+): ValidatorChecklistCompletion {
+  const responseId = Number(response.id);
+  const indicator = response.indicator ?? {};
+  const checklistItems = Array.isArray(indicator.checklist_items) ? indicator.checklist_items : [];
+  const validationRule = indicator.validation_rule || "ALL_ITEMS_REQUIRED";
+  const validatableItems = checklistItems.filter(
+    (item: AnyRecord) =>
+      item.item_type !== "info_text" && !item.mov_description?.startsWith("Note:")
+  );
+
+  if (validatableItems.length === 0) {
+    return { isComplete: false, validatableItemCount: 0 };
+  }
+
+  const groupedItems: Record<string, AnyRecord[]> = {};
+  const ungroupedItems: AnyRecord[] = [];
+
+  for (const item of validatableItems) {
+    if (item.option_group) {
+      groupedItems[item.option_group] ??= [];
+      groupedItems[item.option_group].push(item);
+    } else {
+      ungroupedItems.push(item);
+    }
+  }
+
+  const groupNames = Object.keys(groupedItems);
+  if (groupNames.length > 0) {
+    const ungroupedComplete = ungroupedItems.every((item) =>
+      isChecklistItemFilled(responseId, item, checklistState)
+    );
+
+    if (!ungroupedComplete) {
+      return { isComplete: false, validatableItemCount: validatableItems.length };
+    }
+
+    const anyGroupComplete = groupNames.some((groupName) => {
+      const group = groupedItems[groupName];
+      const hasInternalOr = groupName.includes("Option 3") || groupName.includes("OPTION 3");
+
+      return hasInternalOr
+        ? group.some((item) => isChecklistItemFilled(responseId, item, checklistState))
+        : group.every((item) => isChecklistItemFilled(responseId, item, checklistState));
+    });
+
+    return { isComplete: anyGroupComplete, validatableItemCount: validatableItems.length };
+  }
+
+  if (validationRule === "ANY_ITEM_REQUIRED" || validationRule === "OR_LOGIC_AT_LEAST_1_REQUIRED") {
+    return {
+      isComplete: validatableItems.some((item) =>
+        isChecklistItemFilled(responseId, item, checklistState)
+      ),
+      validatableItemCount: validatableItems.length,
+    };
+  }
+
+  const requiredItems = validatableItems.filter(
+    (item: AnyRecord) => item.required || validationRule === "ALL_ITEMS_REQUIRED"
+  );
+  const itemsToCheck = requiredItems.length > 0 ? requiredItems : validatableItems;
+
+  return {
+    isComplete: itemsToCheck.every((item) =>
+      isChecklistItemFilled(responseId, item, checklistState)
+    ),
+    validatableItemCount: validatableItems.length,
+  };
+}
+
+export function hasExistingValidationStatus(response: AnyRecord): boolean {
+  const status = response.validation_status;
+  if (!status) return false;
+  return ["PASS", "FAIL", "CONDITIONAL"].includes(String(status).toUpperCase());
+}
+
+export function hasActiveValidatorMovAttention(
+  response: AnyRecord,
+  options: { localMovAttentionByFileId: Record<number, boolean | undefined> }
+): boolean {
+  const files = Array.isArray(response.movs) ? response.movs : [];
+
+  return files.some((file) => {
+    if (!isBlguEvidenceFile(file)) return false;
+    if (isSupersededBlguMovFile(file, files)) return false;
+
+    const fileId = Number(file.id);
+    const hasLocalAttention =
+      Number.isFinite(fileId) && options.localMovAttentionByFileId[fileId] === true;
+
+    return hasValidatorFileFeedback(file) || hasLocalAttention;
+  });
+}
+
+export function getValidatorIndicatorProgress(
+  response: AnyRecord,
+  input: ValidatorProgressInput
+): ValidatorIndicatorProgress {
+  const hasMovNotes =
+    input.responseCalibrationFlag ||
+    hasActiveValidatorMovAttention(response, {
+      localMovAttentionByFileId: input.localMovAttentionByFileId,
+    });
+  const checklistCompletion = getValidatorChecklistCompletion(response, input.checklistState);
+
+  const reviewed = input.strictChecklistRequired
+    ? checklistCompletion.isComplete || hasMovNotes
+    : checklistCompletion.isComplete || hasMovNotes || hasExistingValidationStatus(response);
+
+  return {
+    status: reviewed ? "completed" : "not_started",
+    hasMovNotes,
+  };
+}

--- a/apps/web/src/components/features/validator/validator-progress.ts
+++ b/apps/web/src/components/features/validator/validator-progress.ts
@@ -187,7 +187,7 @@ export function getValidatorIndicatorProgress(
   const checklistCompletion = getValidatorChecklistCompletion(response, input.checklistState);
 
   const reviewed = input.strictChecklistRequired
-    ? checklistCompletion.isComplete || hasMovNotes
+    ? checklistCompletion.isComplete && !hasMovNotes
     : checklistCompletion.isComplete || hasMovNotes || hasExistingValidationStatus(response);
 
   return {

--- a/apps/web/src/components/features/validator/validator-progress.ts
+++ b/apps/web/src/components/features/validator/validator-progress.ts
@@ -3,7 +3,6 @@ type AnyRecord = Record<string, any>;
 export interface ValidatorProgressInput {
   checklistState: Record<string, any>;
   localMovAttentionByFileId: Record<number, boolean | undefined>;
-  responseCalibrationFlag: boolean;
   strictChecklistRequired: boolean;
 }
 
@@ -179,11 +178,9 @@ export function getValidatorIndicatorProgress(
   response: AnyRecord,
   input: ValidatorProgressInput
 ): ValidatorIndicatorProgress {
-  const hasMovNotes =
-    input.responseCalibrationFlag ||
-    hasActiveValidatorMovAttention(response, {
-      localMovAttentionByFileId: input.localMovAttentionByFileId,
-    });
+  const hasMovNotes = hasActiveValidatorMovAttention(response, {
+    localMovAttentionByFileId: input.localMovAttentionByFileId,
+  });
   const checklistCompletion = getValidatorChecklistCompletion(response, input.checklistState);
 
   const reviewed = input.strictChecklistRequired

--- a/apps/web/src/components/features/validator/validator-progress.ts
+++ b/apps/web/src/components/features/validator/validator-progress.ts
@@ -82,9 +82,11 @@ export function getValidatorChecklistCompletion(
 ): ValidatorChecklistCompletion {
   const responseId = Number(response.id);
   const indicator = response.indicator ?? {};
-  const checklistItems = Array.isArray(indicator.checklist_items) ? indicator.checklist_items : [];
+  const checklistItems: AnyRecord[] = Array.isArray(indicator.checklist_items)
+    ? indicator.checklist_items
+    : [];
   const validationRule = indicator.validation_rule || "ALL_ITEMS_REQUIRED";
-  const validatableItems = checklistItems.filter(
+  const validatableItems: AnyRecord[] = checklistItems.filter(
     (item: AnyRecord) =>
       item.item_type !== "info_text" && !item.mov_description?.startsWith("Note:")
   );
@@ -116,7 +118,7 @@ export function getValidatorChecklistCompletion(
     }
 
     const anyGroupComplete = groupNames.some((groupName) => {
-      const group = groupedItems[groupName];
+      const group = groupedItems[groupName] ?? [];
       const hasInternalOr = groupName.includes("Option 3") || groupName.includes("OPTION 3");
 
       return hasInternalOr


### PR DESCRIPTION
## Summary
- Fixes SNG-38 by deriving validator sidebar progress from checklist completion plus active BLGU MOV attention.
- Adds field-scoped MOV supersession so old BLGU feedback is ignored only when replaced by a newer clean BLGU file for the same `field_id`.
- Prevents validator uploads and stale response-level calibration flags from clearing or forcing sidebar MOV attention incorrectly.

## Details
- Extracted shared validator progress/MOV relevance rules into `validator-progress.ts`.
- Reused shared MOV feedback and supersession helpers in `MiddleMovFilesPanel.tsx`.
- Wired `ValidatorValidationClient.tsx` sidebar indicators to the shared strict post-calibration rules.
- Added unit and rendered regressions for checklist completion, option groups, active/superseded MOV feedback, validator-origin uploads, local MOV edits, and stale response flags.

## Test Plan
- [x] `pnpm --filter web exec vitest run src/components/features/validator/__tests__/validator-progress.test.ts src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx src/components/features/assessor/validation/__tests__/MiddleMovFilesPanel.grouping.test.tsx src/components/features/assessor/validation/__tests__/MiddleMovFilesPanel.test.tsx src/components/features/assessments/tree-navigation/__tests__/AssessmentTreeNode.test.tsx`
- [x] `pnpm --filter web exec eslint src/components/features/validator/validator-progress.ts src/components/features/validator/ValidatorValidationClient.tsx src/components/features/validator/__tests__/validator-progress.test.ts src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx src/components/features/assessor/validation/MiddleMovFilesPanel.tsx src/components/features/assessor/validation/__tests__/MiddleMovFilesPanel.grouping.test.tsx --config eslint.config.mjs` (0 errors, existing warnings only)
- [x] `pnpm --filter web exec tsc --noEmit --pretty false 2>&1 | rg "src/components/features/validator/validator-progress.ts|src/components/features/validator/ValidatorValidationClient.tsx|src/components/features/assessor/validation/MiddleMovFilesPanel.tsx"` (no matching touched-file errors)
- [ ] `pnpm test:web` currently has unrelated baseline failures in navigation, analytics, assessor real-panel/rework, and submit button tests.

## Manual QA Notes
- In a post-calibration validator review, a sidebar indicator turns green only when the validator checklist is complete and all active BLGU files are clean.
- A newer clean BLGU upload supersedes old feedback only for the same MOV `field_id`.
- Newer uploads for other fields and validator-origin uploads do not supersede old BLGU warnings.
- A stale response-level calibration flag no longer forces a red sidebar icon if active same-field BLGU evidence is clean.

Closes SNG-38.
