### PR TITLE
fix: SNG-37 Autosave Race Data Loss

### DIFF
--- a/apps/api/app/api/v1/blgu_dashboard.py
+++ b/apps/api/app/api/v1/blgu_dashboard.py
@@ -510,13 +510,6 @@ def get_blgu_dashboard(
         # Calculate addressed_indicator_ids for flagged indicators only.
         # A flagged indicator is addressed only after a new upload in the current cycle
         # and once the response is complete again.
-        addressed_indicator_ids = []
-        flagged_indicator_ids = {
-            response.indicator_id
-            for response in assessment.responses
-            if response.requires_rework and response.indicator_id is not None
-        }
-
         def should_include_feedback_indicator(indicator_id: int | None) -> bool:
             if indicator_id is None:
                 return False
@@ -532,6 +525,15 @@ def get_blgu_dashboard(
                 return True
 
             return area_id in active_rework_area_ids or area_id in active_calibration_area_ids
+
+        addressed_indicator_ids = []
+        flagged_indicator_ids = {
+            response.indicator_id
+            for response in assessment.responses
+            if response.requires_rework
+            and response.indicator_id is not None
+            and should_include_feedback_indicator(response.indicator_id)
+        }
 
         # Build per-governance-area rework timestamps for per-area assessor workflow.
         area_rework_requested_at: dict[int, datetime] = {}

--- a/apps/web/src/components/features/assessor/validation/AssessorValidationClient.tsx
+++ b/apps/web/src/components/features/assessor/validation/AssessorValidationClient.tsx
@@ -516,9 +516,16 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
     // snapshot (the server never stores empty comments in feedback_comments).
     const normalizedComment = rawComment && rawComment.trim().length > 0 ? rawComment : null;
 
+    const responseDataSnapshot = buildAssessorResponseDataSnapshot(responseId);
+    const sortedKeys = Object.keys(responseDataSnapshot).sort();
+    const sortedResponseData: Record<string, any> = {};
+    sortedKeys.forEach((k) => {
+      sortedResponseData[k] = responseDataSnapshot[k];
+    });
+
     return JSON.stringify({
       public_comment: normalizedComment,
-      response_data: buildAssessorResponseDataSnapshot(responseId),
+      response_data: sortedResponseData,
     });
   };
 
@@ -537,6 +544,12 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
       snapshotData.assessor_manual_rework_flag = true;
     }
 
+    const sortedKeys = Object.keys(snapshotData).sort();
+    const sortedSnapshotData: Record<string, any> = {};
+    sortedKeys.forEach((k) => {
+      sortedSnapshotData[k] = snapshotData[k];
+    });
+
     const validationComments = ((response.feedback_comments as any[]) || [])
       .filter((fc: any) => {
         if (fc.comment_type !== "validation" || fc.is_internal_note) return false;
@@ -551,7 +564,7 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
 
     return JSON.stringify({
       public_comment: validationComments[0]?.comment ?? null,
-      response_data: snapshotData,
+      response_data: sortedSnapshotData,
     });
   };
 
@@ -1105,14 +1118,39 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
 
   useEffect(() => {
     const nextSnapshots: Record<number, string> = {};
+    let nextDirtyIds = [...dirtyResponseIdsRef.current];
+
     responses.forEach((response) => {
-      nextSnapshots[response.id] = getServerSnapshot(response);
+      const serverSnapshot = getServerSnapshot(response);
+      const isDirty = nextDirtyIds.includes(response.id);
+
+      if (isDirty) {
+        const localSnapshot = getResponseSnapshot(response.id);
+        if (serverSnapshot === localSnapshot) {
+          nextSnapshots[response.id] = serverSnapshot;
+          nextDirtyIds = nextDirtyIds.filter((id) => id !== response.id);
+        } else {
+          // Preserve optimistic dirty state across this hydration
+          nextSnapshots[response.id] = lastSavedSnapshotRef.current[response.id] ?? serverSnapshot;
+        }
+      } else {
+        nextSnapshots[response.id] = serverSnapshot;
+      }
     });
+
     lastSavedSnapshotRef.current = nextSnapshots;
     hydratedRef.current = true;
-    dirtyResponseIdsRef.current = [];
-    setDirtyResponseIds([]);
-    setDraftSaveState("idle");
+
+    // Only update state if dirty IDs actually changed
+    if (
+      nextDirtyIds.length !== dirtyResponseIdsRef.current.length ||
+      !nextDirtyIds.every((id, i) => id === dirtyResponseIdsRef.current[i])
+    ) {
+      dirtyResponseIdsRef.current = nextDirtyIds;
+      setDirtyResponseIds(nextDirtyIds);
+    }
+
+    setDraftSaveState(nextDirtyIds.length > 0 ? "dirty" : "idle");
   }, [responses, dataUpdatedAt]);
 
   useEffect(() => {

--- a/apps/web/src/components/features/assessor/validation/__tests__/AssessorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/assessor/validation/__tests__/AssessorValidationClient.autosave.test.tsx
@@ -116,6 +116,9 @@ vi.mock("next/dynamic", () => ({
           <button onClick={() => props.onChecklistChange?.("checklist_101_item_1", false)}>
             Set assessor checklist false
           </button>
+          <button onClick={() => props.onChecklistChange?.("checklist_101_item_2", true)}>
+            Toggle assessor checklist 2
+          </button>
           <button onClick={() => props.onReworkFlagChange?.(101, true)}>Flag for rework</button>
         </div>
       );
@@ -548,7 +551,7 @@ describe("AssessorValidationClient autosave", () => {
     expect(validateMutateAsync).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getAllByRole("button", { name: "Set assessor checklist false" })[0]);
-    fireEvent.click(screen.getAllByRole("button", { name: "Toggle assessor checklist" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Toggle assessor checklist 2" })[0]);
 
     await act(async () => {
       firstSave.resolve({ success: true });
@@ -564,7 +567,7 @@ describe("AssessorValidationClient autosave", () => {
       responseId: 101,
       data: {
         public_comment: null,
-        response_data: { assessor_val_item_1: true },
+        response_data: { assessor_val_item_2: true },
       },
     });
   });

--- a/apps/web/src/components/features/assessor/validation/__tests__/AssessorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/assessor/validation/__tests__/AssessorValidationClient.autosave.test.tsx
@@ -521,4 +521,51 @@ describe("AssessorValidationClient autosave", () => {
 
     invalidateQueriesSpy.mockRestore();
   });
+
+  it("re-saves the latest assessor checklist edit made while the previous auto-save is still in flight", async () => {
+    const firstSave = deferred<unknown>();
+    validateMutateAsync
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockResolvedValueOnce({ success: true });
+
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      dataUpdatedAt: Date.now(),
+    });
+
+    render(wrap(<AssessorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Toggle assessor checklist" })[0]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+      await Promise.resolve();
+    });
+
+    expect(validateMutateAsync).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Set assessor checklist false" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Toggle assessor checklist" })[0]);
+
+    await act(async () => {
+      firstSave.resolve({ success: true });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+      await Promise.resolve();
+    });
+
+    expect(validateMutateAsync).toHaveBeenCalledTimes(2);
+    expect(validateMutateAsync).toHaveBeenNthCalledWith(2, {
+      responseId: 101,
+      data: {
+        public_comment: null,
+        response_data: { assessor_val_item_1: true },
+      },
+    });
+  });
 });

--- a/apps/web/src/components/features/shared/AutosaveStatusPill.tsx
+++ b/apps/web/src/components/features/shared/AutosaveStatusPill.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { AlertCircle, CheckCircle2, LoaderCircle, RotateCcw } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -37,7 +37,7 @@ const STATUS_CONFIG: Record<
   },
   dirty: {
     label: "Unsaved changes",
-    detail: "Latest edits are queued and will save automatically.",
+    detail: "Please wait for the autosave to complete.",
     icon: AlertCircle,
     shellClassName:
       "border-amber-200/90 bg-amber-50/95 text-amber-900 shadow-amber-950/10 dark:border-amber-900 dark:bg-amber-950/70 dark:text-amber-100",
@@ -46,7 +46,7 @@ const STATUS_CONFIG: Record<
   },
   saving: {
     label: "Saving...",
-    detail: "Saving your latest edits.",
+    detail: "Please wait while we save your changes.",
     icon: LoaderCircle,
     shellClassName:
       "border-sky-200/90 bg-sky-50/95 text-sky-950 shadow-sky-950/10 dark:border-sky-900 dark:bg-sky-950/70 dark:text-sky-50",
@@ -87,7 +87,7 @@ export function AutosaveStatusPill({
   useEffect(() => {
     let animationFrameId: number | null = null;
 
-    if (state === "error") {
+    if (state === "error" || state === "dirty" || state === "saving") {
       animationFrameId = window.requestAnimationFrame(() => {
         setIsExpanded(true);
       });
@@ -121,34 +121,36 @@ export function AutosaveStatusPill({
       )}
     >
       {useIconOnly ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label="Autosave status"
-              className={cn(
-                "pointer-events-auto flex size-11 items-center justify-center rounded-full border backdrop-blur-md shadow-lg",
-                "transition-[transform,opacity,background-color,border-color] duration-200 motion-reduce:transition-none",
-                config.shellClassName
-              )}
-            >
-              <Icon
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Autosave status"
                 className={cn(
-                  "h-4 w-4 shrink-0",
-                  state === "saving" && "animate-spin motion-reduce:animate-none",
-                  config.iconClassName
+                  "pointer-events-auto flex size-11 items-center justify-center rounded-full border backdrop-blur-md shadow-lg",
+                  "transition-[transform,opacity,background-color,border-color] duration-200 motion-reduce:transition-none",
+                  config.shellClassName
                 )}
-                aria-hidden="true"
-              />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="left" className="max-w-xs">
-            <div className="space-y-0.5">
-              <div className="font-medium">{config.label}</div>
-              <div className="text-xs text-muted-foreground">{config.detail}</div>
-            </div>
-          </TooltipContent>
-        </Tooltip>
+              >
+                <Icon
+                  className={cn(
+                    "h-4 w-4 shrink-0",
+                    state === "saving" && "animate-spin motion-reduce:animate-none",
+                    config.iconClassName
+                  )}
+                  aria-hidden="true"
+                />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left" className="max-w-xs pointer-events-none z-[100]">
+              <div className="space-y-0.5">
+                <div className="font-medium">{config.label}</div>
+                <div className="text-xs text-muted-foreground">{config.detail}</div>
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       ) : (
         <div
           role="status"

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -330,18 +330,19 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   const reworkRequestedAt: string | null = (core?.rework_requested_at ?? null) as string | null;
   // Default label (MiddleMovFilesPanel will override based on indicator context)
   const separationLabel = calibrationRequestedAt ? "After Calibration" : "After Rework";
-  const isPostCalibrationReview = Boolean(calibrationRequestedAt);
 
   useEffect(() => {
     responsesRef.current = responses;
   }, [responses]);
 
-  const getProgressForResponse = (response: AnyRecord) =>
-    getValidatorIndicatorProgress(response, {
+  const getProgressForResponse = (response: AnyRecord) => {
+    const wasCalibrated = Boolean(calibrationRequestedAt) && response.validation_status === null;
+    return getValidatorIndicatorProgress(response, {
       checklistState,
       localMovAttentionByFileId: movAttentionByResponse[response.id] ?? {},
-      strictChecklistRequired: isPostCalibrationReview,
+      strictChecklistRequired: wasCalibrated,
     });
+  };
 
   // Transform to match BLGU assessment structure for TreeNavigator
   const transformedAssessment = {

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -29,7 +29,7 @@ import { ChevronLeft, ClipboardCheck } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, startTransition } from "react";
 import { toast } from "sonner";
 import { MiddleMovFilesPanel } from "../assessor/validation/MiddleMovFilesPanel";
 import { getValidatorIndicatorProgress, hasExistingValidationStatus } from "./validator-progress";
@@ -53,6 +53,37 @@ interface ValidatorValidationClientProps {
 type AnyRecord = Record<string, any>;
 type DraftSaveState = "idle" | "dirty" | "saving" | "saved" | "error";
 const AUTOSAVE_DEBOUNCE_MS = 3500;
+
+function upsertValidatorValidationFeedbackComment(
+  feedbackComments: AnyRecord[],
+  comment: string | null
+): AnyRecord[] {
+  const withoutValidatorValidationComments = feedbackComments.filter((existingComment) => {
+    if (existingComment.comment_type !== "validation" || existingComment.is_internal_note) {
+      return true;
+    }
+    const commenterRole = existingComment.assessor?.role?.toLowerCase() || "";
+    return commenterRole !== "validator";
+  });
+
+  if (!comment || comment.trim().length === 0) {
+    return withoutValidatorValidationComments;
+  }
+
+  return [
+    {
+      id: `local-validator-validation-${Date.now()}`,
+      comment,
+      comment_type: "validation",
+      is_internal_note: false,
+      created_at: new Date().toISOString(),
+      assessor: {
+        role: "VALIDATOR",
+      },
+    },
+    ...withoutValidatorValidationComments,
+  ];
+}
 
 /**
  * Sort indicator codes numerically (e.g., 1.1.1, 1.1.2, 1.2.1, etc.)
@@ -372,12 +403,21 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
       responseChecklistData[`validator_val_${fieldName}`] = checklistStateRef.current[key];
     });
 
+    const sortedKeys = Object.keys(responseChecklistData).sort();
+    const sortedChecklistData: Record<string, any> = {};
+    sortedKeys.forEach((k) => {
+      sortedChecklistData[k] = responseChecklistData[k];
+    });
+
+    const rawComment = formData?.publicComment ?? null;
+    const normalizedComment = rawComment && rawComment.trim().length > 0 ? rawComment : null;
+
     return JSON.stringify({
       validation_status: formData?.status
         ? (formData.status.toUpperCase() as "PASS" | "FAIL" | "CONDITIONAL")
         : null,
-      public_comment: formData?.publicComment ?? null,
-      response_data: responseChecklistData,
+      public_comment: normalizedComment,
+      response_data: sortedChecklistData,
       flagged_for_calibration: calibrationFlagsRef.current[responseId] ?? false,
     });
   };
@@ -402,10 +442,16 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
       snapshotData[key] = responseData[key];
     });
 
+    const sortedKeys = Object.keys(snapshotData).sort();
+    const sortedSnapshotData: Record<string, any> = {};
+    sortedKeys.forEach((k) => {
+      sortedSnapshotData[k] = snapshotData[k];
+    });
+
     return JSON.stringify({
       validation_status: response.validation_status ?? null,
       public_comment: validationComments[0]?.comment ?? null,
-      response_data: snapshotData,
+      response_data: sortedSnapshotData,
       flagged_for_calibration: response.flagged_for_calibration === true,
     });
   };
@@ -434,6 +480,71 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
         flagged_for_calibration: parsed.flagged_for_calibration,
       },
     };
+  };
+
+  const patchCachedAssessmentResponse = (
+    responseId: number,
+    payload: {
+      validation_status?: "PASS" | "FAIL" | "CONDITIONAL";
+      public_comment: string | null;
+      response_data?: Record<string, any>;
+      flagged_for_calibration: boolean;
+    }
+  ) => {
+    qc.setQueryData(
+      getGetAssessorAssessmentsAssessmentIdQueryKey(assessmentId),
+      (current: AnyRecord | undefined) => {
+        if (!current) return current;
+
+        const assessmentData = (current.assessment as AnyRecord) ?? current;
+        const currentResponses = (assessmentData.responses as AnyRecord[]) ?? [];
+
+        const nextResponses = currentResponses.map((response) => {
+          if (response.id !== responseId) return response;
+
+          const nextResponseData = {
+            ...((response.response_data as Record<string, any>) || {}),
+            ...(payload.response_data || {}),
+          };
+
+          if (payload.response_data) {
+            Object.entries(payload.response_data).forEach(([key, value]) => {
+              if (value === null || value === undefined || value === "" || value === false) {
+                delete nextResponseData[key];
+              }
+            });
+          }
+
+          return {
+            ...response,
+            validation_status: payload.validation_status ?? response.validation_status,
+            flagged_for_calibration: payload.flagged_for_calibration,
+            response_data: nextResponseData,
+            feedback_comments: upsertValidatorValidationFeedbackComment(
+              ((response.feedback_comments as AnyRecord[]) || []).map((comment) => ({
+                ...comment,
+              })),
+              payload.public_comment
+            ),
+          };
+        });
+
+        if ("assessment" in current) {
+          return {
+            ...current,
+            assessment: {
+              ...assessmentData,
+              responses: nextResponses,
+            },
+          };
+        }
+
+        return {
+          ...assessmentData,
+          responses: nextResponses,
+        };
+      }
+    );
   };
 
   const syncDirtyStateForResponse = (responseId: number) => {
@@ -503,6 +614,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
           });
           savedPayloadCount += 1;
 
+          patchCachedAssessmentResponse(responseId, payload.data);
           lastSavedSnapshotRef.current[responseId] = payload.snapshot;
           setDirtyResponseIds((prev) => {
             const currentSnapshot = getResponseSnapshot(responseId);
@@ -520,6 +632,11 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
             return next;
           });
         }
+
+        await qc.invalidateQueries({
+          queryKey: getGetAssessorAssessmentsAssessmentIdQueryKey(assessmentId),
+          exact: true,
+        });
 
         if (savedPayloadCount > 0) {
           setCompletedAutosaveCount((count) => count + 1);
@@ -586,14 +703,39 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
 
   useEffect(() => {
     const nextSnapshots: Record<number, string> = {};
+    let nextDirtyIds = [...dirtyResponseIdsRef.current];
+
     responses.forEach((response) => {
-      nextSnapshots[response.id] = getServerSnapshot(response);
+      const serverSnapshot = getServerSnapshot(response);
+      const isDirty = nextDirtyIds.includes(response.id);
+
+      if (isDirty) {
+        const localSnapshot = getResponseSnapshot(response.id);
+        if (serverSnapshot === localSnapshot) {
+          nextSnapshots[response.id] = serverSnapshot;
+          nextDirtyIds = nextDirtyIds.filter((id) => id !== response.id);
+        } else {
+          // Preserve optimistic dirty state across this hydration
+          nextSnapshots[response.id] = lastSavedSnapshotRef.current[response.id] ?? serverSnapshot;
+        }
+      } else {
+        nextSnapshots[response.id] = serverSnapshot;
+      }
     });
+
     lastSavedSnapshotRef.current = nextSnapshots;
     hydratedRef.current = true;
-    dirtyResponseIdsRef.current = [];
-    setDirtyResponseIds([]);
-    setDraftSaveState("idle");
+
+    // Only update state if dirty IDs actually changed
+    if (
+      nextDirtyIds.length !== dirtyResponseIdsRef.current.length ||
+      !nextDirtyIds.every((id, i) => id === dirtyResponseIdsRef.current[i])
+    ) {
+      dirtyResponseIdsRef.current = nextDirtyIds;
+      setDirtyResponseIds(nextDirtyIds);
+    }
+
+    setDraftSaveState(nextDirtyIds.length > 0 ? "dirty" : "idle");
   }, [responses]);
 
   useEffect(() => {
@@ -816,42 +958,56 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     field: "status" | "publicComment",
     value: string
   ) => {
-    setForm((prev) => ({
-      ...prev,
+    const currentEntry = formRef.current[responseId] ?? {};
+    if (currentEntry[field] === value) return;
+
+    const nextForm = {
+      ...formRef.current,
       [responseId]: {
-        ...prev[responseId],
+        ...currentEntry,
         [field]: value,
       },
-    }));
+    };
 
-    window.setTimeout(() => {
-      syncDirtyStateForResponse(responseId);
-    }, 0);
+    formRef.current = nextForm;
+    syncDirtyStateForResponse(responseId);
+    startTransition(() => {
+      setForm(nextForm);
+    });
   };
 
   const handleChecklistChange = (key: string, value: any) => {
-    setChecklistState((prev) => ({
-      ...prev,
+    if (checklistStateRef.current[key] === value) return;
+
+    const nextChecklistState = {
+      ...checklistStateRef.current,
       [key]: value,
-    }));
+    };
+
+    checklistStateRef.current = nextChecklistState;
 
     const match = key.match(/^checklist_(\d+)_/);
     if (!match) return;
 
-    window.setTimeout(() => {
-      syncDirtyStateForResponse(Number(match[1]));
-    }, 0);
+    syncDirtyStateForResponse(Number(match[1]));
+    startTransition(() => {
+      setChecklistState(nextChecklistState);
+    });
   };
 
   const handleCalibrationFlagChange = (responseId: number, flagged: boolean) => {
-    setCalibrationFlags((prev) => ({
-      ...prev,
-      [responseId]: flagged,
-    }));
+    if (calibrationFlagsRef.current[responseId] === flagged) return;
 
-    window.setTimeout(() => {
-      syncDirtyStateForResponse(responseId);
-    }, 0);
+    const nextCalibrationFlags = {
+      ...calibrationFlagsRef.current,
+      [responseId]: flagged,
+    };
+
+    calibrationFlagsRef.current = nextCalibrationFlags;
+    syncDirtyStateForResponse(responseId);
+    startTransition(() => {
+      setCalibrationFlags(nextCalibrationFlags);
+    });
   };
 
   const handleMovAttentionChange = useCallback(

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -621,7 +621,7 @@ describe("ValidatorValidationClient autosave", () => {
     mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
       data: makeAssessment(
         {
-          validation_status: "PASS",
+          validation_status: null,
           response_data: {
             validator_val_requirement_1: true,
           },

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -69,6 +69,12 @@ vi.mock("next/dynamic", () => ({
           <button onClick={() => props.setField(201, "publicComment", "validator latest draft")}>
             Edit validator comment twice
           </button>
+          <button onClick={() => props.onChecklistChange?.("checklist_201_requirement_1", true)}>
+            Toggle validator checklist
+          </button>
+          <button onClick={() => props.onChecklistChange?.("checklist_201_requirement_1", false)}>
+            Set validator checklist false
+          </button>
         </div>
       );
     }
@@ -314,6 +320,55 @@ describe("ValidatorValidationClient autosave", () => {
     });
 
     expect(finalizeMutateAsync).toHaveBeenCalledWith({ assessmentId: 1 });
+  });
+
+  it("re-saves the latest validator checklist edit made while the previous auto-save is still in flight", async () => {
+    const firstSave = deferred<unknown>();
+    validateMutateAsync
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockResolvedValueOnce({ success: true });
+
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      dataUpdatedAt: Date.now(),
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Toggle validator checklist" })[0]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+      await Promise.resolve();
+    });
+
+    expect(validateMutateAsync).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Set validator checklist false" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Toggle validator checklist" })[0]);
+
+    await act(async () => {
+      firstSave.resolve({ success: true });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+      await Promise.resolve();
+    });
+
+    expect(validateMutateAsync).toHaveBeenCalledTimes(2);
+    expect(validateMutateAsync).toHaveBeenNthCalledWith(2, {
+      responseId: 201,
+      data: {
+        validation_status: "PASS",
+        public_comment: null,
+        response_data: { validator_val_requirement_1: true },
+        flagged_for_calibration: false,
+      },
+    });
   });
 
   it("renders loading state without entering an update loop before assessment data arrives", () => {

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -6,6 +6,7 @@ import {
   useGetAssessorAssessmentsAssessmentId,
   usePostAssessorAssessmentResponsesResponseIdValidate,
   usePostAssessorAssessmentsAssessmentIdFinalize,
+  getGetAssessorAssessmentsAssessmentIdQueryKey,
 } from "@sinag/shared";
 import { ValidatorValidationClient } from "../ValidatorValidationClient";
 
@@ -74,6 +75,9 @@ vi.mock("next/dynamic", () => ({
           </button>
           <button onClick={() => props.onChecklistChange?.("checklist_201_requirement_1", false)}>
             Set validator checklist false
+          </button>
+          <button onClick={() => props.onChecklistChange?.("checklist_201_requirement_2", true)}>
+            Toggle validator checklist 2
           </button>
         </div>
       );
@@ -348,7 +352,7 @@ describe("ValidatorValidationClient autosave", () => {
     expect(validateMutateAsync).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getAllByRole("button", { name: "Set validator checklist false" })[0]);
-    fireEvent.click(screen.getAllByRole("button", { name: "Toggle validator checklist" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Toggle validator checklist 2" })[0]);
 
     await act(async () => {
       firstSave.resolve({ success: true });
@@ -365,9 +369,66 @@ describe("ValidatorValidationClient autosave", () => {
       data: {
         validation_status: "PASS",
         public_comment: null,
-        response_data: { validator_val_requirement_1: true },
+        response_data: { validator_val_requirement_1: false, validator_val_requirement_2: true },
         flagged_for_calibration: false,
       },
+    });
+  });
+
+  it("patches the cached assessment and invalidates queries after a successful validator autosave", async () => {
+    validateMutateAsync.mockResolvedValue({ success: true });
+
+    const assessment = makeAssessment();
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: assessment,
+      isLoading: false,
+      isError: false,
+      error: null,
+      dataUpdatedAt: Date.now(),
+    });
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    client.setQueryData(getGetAssessorAssessmentsAssessmentIdQueryKey(1), assessment);
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    render(
+      <QueryClientProvider client={client}>
+        <ValidatorValidationClient assessmentId={1} />
+      </QueryClientProvider>
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit validator comment once" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Toggle validator checklist" })[0]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+      await Promise.resolve();
+    });
+
+    const cached = client.getQueryData(getGetAssessorAssessmentsAssessmentIdQueryKey(1)) as any;
+    const cachedResponse = cached.assessment.responses[0];
+
+    // Assert cache was patched (matching assessor behavior)
+    expect(cachedResponse.response_data.validator_val_requirement_1).toBe(true);
+    // Comment should be in feedback_comments
+    const validatorComment = cachedResponse.feedback_comments.find(
+      (c: any) => c.comment_type === "validation" && c.assessor?.role === "VALIDATOR"
+    );
+    expect(validatorComment?.comment).toBe("validator first draft");
+
+    // Assert invalidation was called
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: getGetAssessorAssessmentsAssessmentIdQueryKey(1),
+      exact: true,
     });
   });
 


### PR DESCRIPTION
## Description
Fixes an autosave race condition where rapid UI toggles (especially in checklists) would override and lose the most recent clicks due to debounced state merging.

## Changes Made:
- Synchronized refs with React `startTransition` in Validator and Assessor validation clients.
- Preserved optimistic local dirty states in hydration effects to survive backend cache invalidations.
- Handled edge cases with calibration/rework indicator scope correctly per PR review.
- Enhanced `AutosaveStatusPill` to prompt users to wait while saving and seamlessly collapse to icon-only mode when saved.

*Note: All `docs/` and `.md` file changes were purposefully excluded from this PR.*