### PR TITLE
fix: refine compliance suggestions and overview feedback

### DIFF
--- a/apps/api/app/services/compliance_service.py
+++ b/apps/api/app/services/compliance_service.py
@@ -353,10 +353,7 @@ class ComplianceService:
 
             # Fallback: Auto-calculate compliance from values if explicit CHECKBOX is missing
             # For indicators: 2.1.4, 3.2.3, 4.1.6, 4.3.4, 4.5.6, 4.8.4, 6.1.4
-            if (
-                not has_passing_option
-                and indicator.indicator_code in PHYSICAL_FINANCIAL_INDICATORS
-            ):
+            if not has_passing_option and indicator.indicator_code in PHYSICAL_FINANCIAL_INDICATORS:
                 code_safe = indicator.indicator_code.replace(".", "_")
 
                 # Check Physical (Option A) keys

--- a/apps/api/app/services/compliance_service.py
+++ b/apps/api/app/services/compliance_service.py
@@ -22,6 +22,7 @@ from app.schemas.compliance import (
     SubIndicatorStatus,
 )
 from app.services.bbi_service import BBI_CONFIG, get_bbi_rating_by_count
+from app.services.checklist_utils import PHYSICAL_FINANCIAL_INDICATORS
 
 
 class ComplianceService:
@@ -128,21 +129,25 @@ class ComplianceService:
         # immediately return FAIL (Unmet). This handles all assessment_field items
         # with YES/NO options where NO indicates failure.
         indicator_code_safe = (indicator.indicator_code or "").replace(".", "_")
+        validation_rule = indicator.validation_rule or "ALL_ITEMS_REQUIRED"
 
-        for key, value in response_data.items():
-            # Check if this is a NO response for this indicator from VALIDATOR only
-            # Key format: validator_val_{item_id}_no (NOT assessor - we only care about validator's decision)
-            # where item_id contains indicator code
-            if (
-                key.startswith("validator_val_")
-                and key.endswith("_no")
-                and indicator_code_safe in key
-                and (value is True or value == 1 or str(value).lower() in ("true", "1"))
-            ):
-                self.logger.debug(
-                    f"Indicator {indicator.indicator_code}: Unmet - NO checked: {key}"
-                )
-                return False, True  # Not complete, but has checklist data
+        should_fail_fast_on_no = validation_rule == "ALL_ITEMS_REQUIRED"
+
+        if should_fail_fast_on_no:
+            for key, value in response_data.items():
+                # Check if this is a NO response for this indicator from VALIDATOR only
+                # Key format: validator_val_{item_id}_no (NOT assessor - we only care about validator's decision)
+                # where item_id contains indicator code
+                if (
+                    key.startswith("validator_val_")
+                    and key.endswith("_no")
+                    and indicator_code_safe in key
+                    and (value is True or value == 1 or str(value).lower() in ("true", "1"))
+                ):
+                    self.logger.debug(
+                        f"Indicator {indicator.indicator_code}: Unmet - NO checked: {key}"
+                    )
+                    return False, True  # Not complete, but has checklist data
 
         # Find all validator checklist items with meaningful values
         # Key format: validator_val_{item_id} (e.g., validator_val_1_2_1_a)
@@ -234,8 +239,6 @@ class ComplianceService:
         # If still no checklist definition, assume complete if any item checked
         if not checklist_items_data:
             return True, True
-
-        validation_rule = indicator.validation_rule or "ALL_ITEMS_REQUIRED"
 
         if validation_rule == "ANY_OPTION_GROUP_REQUIRED":
             # OR logic with option groups: at least one COMPLETE option group
@@ -350,15 +353,10 @@ class ComplianceService:
 
             # Fallback: Auto-calculate compliance from values if explicit CHECKBOX is missing
             # For indicators: 2.1.4, 3.2.3, 4.1.6, 4.3.4, 4.5.6, 4.8.4, 6.1.4
-            if not has_passing_option and indicator.indicator_code in [
-                "2.1.4",
-                "3.2.3",
-                "4.1.6",
-                "4.3.4",
-                "4.5.6",
-                "4.8.4",
-                "6.1.4",
-            ]:
+            if (
+                not has_passing_option
+                and indicator.indicator_code in PHYSICAL_FINANCIAL_INDICATORS
+            ):
                 code_safe = indicator.indicator_code.replace(".", "_")
 
                 # Check Physical (Option A) keys

--- a/apps/api/app/services/compliance_service.py
+++ b/apps/api/app/services/compliance_service.py
@@ -316,6 +316,9 @@ class ComplianceService:
             # b) Any assessment_field with _yes checked
 
             has_passing_option = False
+            is_physical_financial_indicator = (
+                indicator.indicator_code in PHYSICAL_FINANCIAL_INDICATORS
+            )
 
             # Get all item IDs defined for this indicator
             all_item_ids = {item.get("item_id") for item in checklist_items_data}
@@ -323,10 +326,14 @@ class ComplianceService:
             # Get checkbox items (regular options like option_1, option_2)
             # IMPORTANT: Exclude required items (shared requirements) from option checkboxes
             # e.g., 4_1_6_report is a required SHARED item, not an OR option
+            # Physical/Financial report indicators use checkbox rows for supporting certifications,
+            # so their pass/fail result must come from the auto YES/NO fields or numeric fallback.
             checkbox_items = [
                 item.get("item_id")
                 for item in checklist_items_data
-                if item.get("item_type") == "checkbox" and not item.get("required", False)
+                if not is_physical_financial_indicator
+                and item.get("item_type") == "checkbox"
+                and not item.get("required", False)
             ]
 
             # Check if any checkbox option is checked
@@ -353,7 +360,7 @@ class ComplianceService:
 
             # Fallback: Auto-calculate compliance from values if explicit CHECKBOX is missing
             # For indicators: 2.1.4, 3.2.3, 4.1.6, 4.3.4, 4.5.6, 4.8.4, 6.1.4
-            if not has_passing_option and indicator.indicator_code in PHYSICAL_FINANCIAL_INDICATORS:
+            if not has_passing_option and is_physical_financial_indicator:
                 code_safe = indicator.indicator_code.replace(".", "_")
 
                 # Check Physical (Option A) keys

--- a/apps/api/tests/services/test_compliance_service.py
+++ b/apps/api/tests/services/test_compliance_service.py
@@ -25,8 +25,18 @@ def make_report_indicator(code: str = "4.1.6") -> SimpleNamespace:
                 "required": False,
             },
             {
+                "item_id": f"{code_safe}_cert_physical",
+                "item_type": "checkbox",
+                "required": False,
+            },
+            {
                 "item_id": f"{code_safe}_option_b",
                 "item_type": "assessment_field",
+                "required": False,
+            },
+            {
+                "item_id": f"{code_safe}_cert_financial",
+                "item_type": "checkbox",
                 "required": False,
             },
         ],
@@ -99,6 +109,29 @@ def test_report_or_indicator_is_incomplete_when_physical_and_financial_are_no(
             f"validator_val_{code_safe}_report": True,
             f"validator_val_{code_safe}_option_a_no": True,
             f"validator_val_{code_safe}_option_b_no": True,
+        }
+    )
+
+    is_complete, has_any_checked = service._is_checklist_complete(
+        db=SimpleNamespace(),
+        indicator=cast(Any, indicator),
+        response=cast(Any, response),
+    )
+
+    assert is_complete is False
+    assert has_any_checked is True
+
+
+def test_report_or_indicator_is_incomplete_when_certifications_are_checked_but_rates_are_no():
+    service = ComplianceService()
+    indicator = make_report_indicator("4.1.6")
+    response = make_response(
+        {
+            "validator_val_4_1_6_report": True,
+            "validator_val_4_1_6_cert_physical": True,
+            "validator_val_4_1_6_option_a_no": True,
+            "validator_val_4_1_6_cert_financial": True,
+            "validator_val_4_1_6_option_b_no": True,
         }
     )
 

--- a/apps/api/tests/services/test_compliance_service.py
+++ b/apps/api/tests/services/test_compliance_service.py
@@ -1,0 +1,121 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+from app.services.compliance_service import ComplianceService
+
+
+def make_report_indicator(code: str = "4.1.6") -> SimpleNamespace:
+    code_safe = code.replace(".", "_")
+    return SimpleNamespace(
+        indicator_code=code,
+        validation_rule="SHARED_PLUS_OR_LOGIC",
+        mov_checklist_items=[
+            {
+                "item_id": f"{code_safe}_report",
+                "item_type": "checkbox",
+                "required": True,
+            },
+            {
+                "item_id": f"{code_safe}_option_a",
+                "item_type": "assessment_field",
+                "required": False,
+            },
+            {
+                "item_id": f"{code_safe}_option_b",
+                "item_type": "assessment_field",
+                "required": False,
+            },
+        ],
+    )
+
+
+def make_response(response_data: dict) -> SimpleNamespace:
+    return SimpleNamespace(response_data=response_data)
+
+
+def test_report_or_indicator_is_complete_when_physical_yes_and_financial_no():
+    service = ComplianceService()
+    indicator = make_report_indicator("4.1.6")
+    response = make_response(
+        {
+            "validator_val_4_1_6_report": True,
+            "validator_val_4_1_6_option_a_yes": True,
+            "validator_val_4_1_6_option_b_no": True,
+        }
+    )
+
+    is_complete, has_any_checked = service._is_checklist_complete(
+        db=SimpleNamespace(),
+        indicator=cast(Any, indicator),
+        response=cast(Any, response),
+    )
+
+    assert is_complete is True
+    assert has_any_checked is True
+
+
+def test_report_or_indicator_is_complete_when_physical_no_and_financial_yes():
+    service = ComplianceService()
+    indicator = make_report_indicator("4.1.6")
+    response = make_response(
+        {
+            "validator_val_4_1_6_report": True,
+            "validator_val_4_1_6_option_a_no": True,
+            "validator_val_4_1_6_option_b_yes": True,
+        }
+    )
+
+    is_complete, has_any_checked = service._is_checklist_complete(
+        db=SimpleNamespace(),
+        indicator=cast(Any, indicator),
+        response=cast(Any, response),
+    )
+
+    assert is_complete is True
+    assert has_any_checked is True
+
+
+def test_report_or_indicator_is_incomplete_when_physical_and_financial_are_no():
+    service = ComplianceService()
+    indicator = make_report_indicator("4.1.6")
+    response = make_response(
+        {
+            "validator_val_4_1_6_report": True,
+            "validator_val_4_1_6_option_a_no": True,
+            "validator_val_4_1_6_option_b_no": True,
+        }
+    )
+
+    is_complete, has_any_checked = service._is_checklist_complete(
+        db=SimpleNamespace(),
+        indicator=cast(Any, indicator),
+        response=cast(Any, response),
+    )
+
+    assert is_complete is False
+    assert has_any_checked is True
+
+
+def test_non_report_indicator_still_fails_fast_on_any_no_answer():
+    service = ComplianceService()
+    indicator = SimpleNamespace(
+        indicator_code="2.2.1",
+        validation_rule="ALL_ITEMS_REQUIRED",
+        mov_checklist_items=[
+            {
+                "item_id": "2_2_1_a",
+                "item_type": "assessment_field",
+                "required": True,
+            }
+        ],
+    )
+    response = make_response({"validator_val_2_2_1_a_no": True})
+
+    is_complete, has_any_checked = service._is_checklist_complete(
+        db=SimpleNamespace(),
+        indicator=cast(Any, indicator),
+        response=cast(Any, response),
+    )
+
+    assert is_complete is False
+    assert has_any_checked is True

--- a/apps/api/tests/services/test_compliance_service.py
+++ b/apps/api/tests/services/test_compliance_service.py
@@ -5,7 +5,6 @@ import pytest
 
 from app.services.compliance_service import ComplianceService
 
-
 REPORT_OR_INDICATOR_CODES = ["2.1.4", "3.2.3", "4.1.6", "4.3.4", "4.5.6", "4.8.4", "6.1.4"]
 
 

--- a/apps/api/tests/services/test_compliance_service.py
+++ b/apps/api/tests/services/test_compliance_service.py
@@ -1,7 +1,12 @@
 from types import SimpleNamespace
 from typing import Any, cast
 
+import pytest
+
 from app.services.compliance_service import ComplianceService
+
+
+REPORT_OR_INDICATOR_CODES = ["2.1.4", "3.2.3", "4.1.6", "4.3.4", "4.5.6", "4.8.4", "6.1.4"]
 
 
 def make_report_indicator(code: str = "4.1.6") -> SimpleNamespace:
@@ -33,14 +38,18 @@ def make_response(response_data: dict) -> SimpleNamespace:
     return SimpleNamespace(response_data=response_data)
 
 
-def test_report_or_indicator_is_complete_when_physical_yes_and_financial_no():
+@pytest.mark.parametrize("indicator_code", REPORT_OR_INDICATOR_CODES)
+def test_report_or_indicator_is_complete_when_physical_yes_and_financial_no(
+    indicator_code: str,
+):
     service = ComplianceService()
-    indicator = make_report_indicator("4.1.6")
+    indicator = make_report_indicator(indicator_code)
+    code_safe = indicator_code.replace(".", "_")
     response = make_response(
         {
-            "validator_val_4_1_6_report": True,
-            "validator_val_4_1_6_option_a_yes": True,
-            "validator_val_4_1_6_option_b_no": True,
+            f"validator_val_{code_safe}_report": True,
+            f"validator_val_{code_safe}_option_a_yes": True,
+            f"validator_val_{code_safe}_option_b_no": True,
         }
     )
 
@@ -54,14 +63,18 @@ def test_report_or_indicator_is_complete_when_physical_yes_and_financial_no():
     assert has_any_checked is True
 
 
-def test_report_or_indicator_is_complete_when_physical_no_and_financial_yes():
+@pytest.mark.parametrize("indicator_code", REPORT_OR_INDICATOR_CODES)
+def test_report_or_indicator_is_complete_when_physical_no_and_financial_yes(
+    indicator_code: str,
+):
     service = ComplianceService()
-    indicator = make_report_indicator("4.1.6")
+    indicator = make_report_indicator(indicator_code)
+    code_safe = indicator_code.replace(".", "_")
     response = make_response(
         {
-            "validator_val_4_1_6_report": True,
-            "validator_val_4_1_6_option_a_no": True,
-            "validator_val_4_1_6_option_b_yes": True,
+            f"validator_val_{code_safe}_report": True,
+            f"validator_val_{code_safe}_option_a_no": True,
+            f"validator_val_{code_safe}_option_b_yes": True,
         }
     )
 
@@ -75,14 +88,18 @@ def test_report_or_indicator_is_complete_when_physical_no_and_financial_yes():
     assert has_any_checked is True
 
 
-def test_report_or_indicator_is_incomplete_when_physical_and_financial_are_no():
+@pytest.mark.parametrize("indicator_code", REPORT_OR_INDICATOR_CODES)
+def test_report_or_indicator_is_incomplete_when_physical_and_financial_are_no(
+    indicator_code: str,
+):
     service = ComplianceService()
-    indicator = make_report_indicator("4.1.6")
+    indicator = make_report_indicator(indicator_code)
+    code_safe = indicator_code.replace(".", "_")
     response = make_response(
         {
-            "validator_val_4_1_6_report": True,
-            "validator_val_4_1_6_option_a_no": True,
-            "validator_val_4_1_6_option_b_no": True,
+            f"validator_val_{code_safe}_report": True,
+            f"validator_val_{code_safe}_option_a_no": True,
+            f"validator_val_{code_safe}_option_b_no": True,
         }
     )
 

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -25,7 +25,7 @@ import {
 } from "@sinag/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { classifyError } from "@/lib/error-utils";
-import { ChevronLeft, ClipboardCheck } from "lucide-react";
+import { ChevronLeft, ClipboardCheck, Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -53,6 +53,12 @@ interface ValidatorValidationClientProps {
 type AnyRecord = Record<string, any>;
 type DraftSaveState = "idle" | "dirty" | "saving" | "saved" | "error";
 const AUTOSAVE_DEBOUNCE_MS = 3500;
+const COMPLIANCE_OVERVIEW_LOADING_MESSAGES = [
+  "Opening overview",
+  "Saving your changes",
+  "Preparing suggestions",
+] as const;
+const COMPLIANCE_OVERVIEW_LOADING_MESSAGE_MS = 2500;
 
 function upsertValidatorValidationFeedbackComment(
   feedbackComments: AnyRecord[],
@@ -133,6 +139,8 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     Record<number, Record<number, boolean>>
   >({});
   const [draftSaveState, setDraftSaveState] = useState<DraftSaveState>("idle");
+  const [isOpeningComplianceOverview, setIsOpeningComplianceOverview] = useState(false);
+  const [complianceOverviewLoadingStep, setComplianceOverviewLoadingStep] = useState(0);
   const [completedAutosaveCount, setCompletedAutosaveCount] = useState(0);
   const [dirtyResponseIds, setDirtyResponseIds] = useState<number[]>([]);
   const hydratedRef = useRef(false);
@@ -311,6 +319,8 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     "") as string;
   const cycleYear: string = String(core?.cycle_year ?? core?.year ?? "");
   const statusText: string = core?.status ?? core?.assessment_status ?? "";
+  const complianceOverviewLoadingMessage =
+    COMPLIANCE_OVERVIEW_LOADING_MESSAGES[complianceOverviewLoadingStep];
 
   // Per-area calibration tracking: each governance area can only be calibrated ONCE
   // calibrated_area_ids contains the IDs of areas that have already been calibrated
@@ -703,6 +713,21 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   };
 
   useEffect(() => {
+    if (!isOpeningComplianceOverview) {
+      setComplianceOverviewLoadingStep(0);
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      setComplianceOverviewLoadingStep((step) =>
+        Math.min(step + 1, COMPLIANCE_OVERVIEW_LOADING_MESSAGES.length - 1)
+      );
+    }, COMPLIANCE_OVERVIEW_LOADING_MESSAGE_MS);
+
+    return () => window.clearInterval(intervalId);
+  }, [isOpeningComplianceOverview]);
+
+  useEffect(() => {
     const nextSnapshots: Record<number, string> = {};
     let nextDirtyIds = [...dirtyResponseIdsRef.current];
 
@@ -1093,17 +1118,37 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
               variant="default"
               size="sm"
               className="gap-1 sm:gap-1.5 bg-blue-600 hover:bg-blue-700 text-white text-xs sm:text-sm px-2 sm:px-4"
-              disabled={draftSaveState === "saving"}
+              disabled={draftSaveState === "saving" || isOpeningComplianceOverview}
+              aria-busy={isOpeningComplianceOverview}
+              aria-label={
+                isOpeningComplianceOverview
+                  ? complianceOverviewLoadingMessage
+                  : "Compliance Overview"
+              }
               onClick={async () => {
                 // Save draft first, then navigate to compliance overview
+                setIsOpeningComplianceOverview(true);
                 const saved = await flushPendingChanges({ quiet: true });
-                if (!saved) return;
+                if (!saved) {
+                  setIsOpeningComplianceOverview(false);
+                  return;
+                }
                 router.push(`/validator/submissions/${assessmentId}/compliance`);
               }}
             >
-              <ClipboardCheck className="h-3 w-3 sm:h-4 sm:w-4" />
-              <span className="hidden sm:inline">Compliance Overview</span>
-              <span className="sm:hidden">Compliance</span>
+              {isOpeningComplianceOverview ? (
+                <Loader2 className="h-3 w-3 animate-spin sm:h-4 sm:w-4" />
+              ) : (
+                <ClipboardCheck className="h-3 w-3 sm:h-4 sm:w-4" />
+              )}
+              <span className="hidden sm:inline">
+                {isOpeningComplianceOverview
+                  ? complianceOverviewLoadingMessage
+                  : "Compliance Overview"}
+              </span>
+              <span className="sm:hidden">
+                {isOpeningComplianceOverview ? complianceOverviewLoadingMessage : "Compliance"}
+              </span>
             </Button>
           </div>
         </div>

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -288,6 +288,74 @@ describe("ValidatorValidationClient autosave", () => {
     });
   });
 
+  it("shows rotating feedback while opening the compliance overview", async () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    const complianceButton = screen.getByRole("button", {
+      name: /compliance overview/i,
+    });
+
+    await act(async () => {
+      fireEvent.click(complianceButton);
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: /opening overview/i,
+      })
+    ).toBeDisabled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1200);
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: /opening overview/i,
+      })
+    ).toBeDisabled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1300);
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: /saving your changes/i,
+      })
+    ).toBeDisabled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: /preparing suggestions/i,
+      })
+    ).toBeDisabled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: /preparing suggestions/i,
+      })
+    ).toBeDisabled();
+
+    expect(routerPush).toHaveBeenCalledWith("/validator/submissions/1/compliance");
+  });
+
   it("waits for an active auto-save before finalizing", async () => {
     const firstSave = deferred<unknown>();
 


### PR DESCRIPTION
## Summary
- Fix compliance overview suggestions for Physical/Financial OR indicators so supporting certification checkboxes do not incorrectly mark failed rates as met.
- Add regression coverage for affected report indicators, including both rates failing while certifications are checked.
- Add calmer opening feedback for the Compliance Overview button with slower, non-looping progress labels while pending changes are saved.

## Test Plan
- [x] cd apps/api && uv run pytest tests/services/test_compliance_service.py -q
- [x] cd apps/api && uv run ruff check app/services/compliance_service.py tests/services/test_compliance_service.py && uv run ruff format --check app/services/compliance_service.py tests/services/test_compliance_service.py
- [x] cd apps/web && pnpm exec vitest run src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx src/components/features/validator/__tests__/validator-progress.test.ts
- [x] cd apps/web && pnpm exec eslint src/components/features/validator/ValidatorValidationClient.tsx src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx --config eslint.config.mjs

## Notes
- The focused ESLint run reports 0 errors and 1 existing react-hooks/exhaustive-deps warning for saveResponses in ValidatorValidationClient.tsx.