### PR TITLE
fix: SNG-37 force save autosave data loss

### DIFF
--- a/apps/web/src/components/features/assessor/validation/AssessorValidationClient.tsx
+++ b/apps/web/src/components/features/assessor/validation/AssessorValidationClient.tsx
@@ -708,7 +708,8 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
       return saveResponses(remainingResponseIds, options);
     }
 
-    const savePromise = (async () => {
+    let savePromise!: Promise<boolean>;
+    savePromise = (async () => {
       isSavingRef.current = true;
       setIsSaving(true);
       setDraftSaveState("saving");

--- a/apps/web/src/components/features/assessor/validation/AssessorValidationClient.tsx
+++ b/apps/web/src/components/features/assessor/validation/AssessorValidationClient.tsx
@@ -667,7 +667,7 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
 
     dirtyResponseIdsRef.current = nextDirtyIds;
     setDirtyResponseIds(nextDirtyIds);
-    setDraftSaveState(nextSnapshot === savedSnapshot ? "saved" : "dirty");
+    setDraftSaveState(nextDirtyIds.length > 0 ? "dirty" : "saved");
   };
 
   const saveResponses = async (
@@ -695,6 +695,12 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
       if (remainingResponseIds.length === 0) {
         if (!options.quiet && dirtyResponseIdsRef.current.length === 0) {
           setDraftSaveState("saved");
+          toast({
+            title: "Saved",
+            description: "Assessment progress saved",
+            duration: 2000,
+            className: "bg-green-600 text-white border-none",
+          });
         }
         return true;
       }

--- a/apps/web/src/components/features/assessor/validation/AssessorValidationClient.tsx
+++ b/apps/web/src/components/features/assessor/validation/AssessorValidationClient.tsx
@@ -134,7 +134,6 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
   >({});
   const [checklistData, setChecklistData] = useState<Record<string, any>>({}); // Store checklist checkbox/input data
   const [expandedId, setExpandedId] = useState<number | null>(null);
-  const [isSaving, setIsSaving] = useState(false); // Local loading state instead of relying on mutation
   const isSavingRef = useRef(false); // Prevent multiple concurrent saves
   const [draftSaveState, setDraftSaveState] = useState<DraftSaveState>("idle");
   const [completedAutosaveCount, setCompletedAutosaveCount] = useState(0);
@@ -406,7 +405,6 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
   // Track if any action is in progress to disable all buttons
   // This prevents users from clicking other buttons while an action is processing
   const isAnyActionPending: boolean =
-    isSaving ||
     areaApproveMut.isPending ||
     areaReworkMut.isPending ||
     finalizeMut.isPending ||
@@ -711,7 +709,6 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
     let savePromise!: Promise<boolean>;
     savePromise = (async () => {
       isSavingRef.current = true;
-      setIsSaving(true);
       setDraftSaveState("saving");
       let savedPayloadCount = 0;
 
@@ -800,7 +797,6 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
         return false;
       } finally {
         isSavingRef.current = false;
-        setIsSaving(false);
         if (activeSavePromiseRef.current === savePromise) {
           activeSavePromiseRef.current = null;
         }
@@ -1186,6 +1182,24 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
   }, [autoFlaggedEmptyIds]);
 
   useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      const hasPendingChanges =
+        dirtyResponseIdsRef.current.length > 0 ||
+        activeSavePromiseRef.current !== null ||
+        autoSaveTimerRef.current !== null;
+      if (!hasPendingChanges) return;
+
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+
+  useEffect(() => {
     const handleDocumentNavigation = (event: MouseEvent) => {
       if (isInterceptingNavigationRef.current) return;
 
@@ -1225,6 +1239,9 @@ export function AssessorValidationClient({ assessmentId }: AssessorValidationCli
         const saved = await flushPendingChanges({ quiet: true });
         if (saved) {
           router.push(`${url.pathname}${url.search}${url.hash}`);
+          window.setTimeout(() => {
+            isInterceptingNavigationRef.current = false;
+          }, 0);
         } else {
           isInterceptingNavigationRef.current = false;
         }

--- a/apps/web/src/components/features/assessor/validation/__tests__/AssessorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/assessor/validation/__tests__/AssessorValidationClient.autosave.test.tsx
@@ -110,6 +110,12 @@ vi.mock("next/dynamic", () => ({
           <button onClick={() => props.setField(101, "publicComment", "latest draft")}>
             Edit assessor comment twice
           </button>
+          <button onClick={() => props.setField(102, "publicComment", "response 102 draft")}>
+            Edit response 102 comment
+          </button>
+          <button onClick={() => props.setField(102, "publicComment", "")}>
+            Revert response 102 comment
+          </button>
           <button onClick={() => props.onChecklistChange?.("checklist_101_item_1", true)}>
             Toggle assessor checklist
           </button>
@@ -193,7 +199,44 @@ function makeAssessment(overrides?: {
   feedbackComments?: any[];
   responseData?: Record<string, unknown>;
   requiresRework?: boolean;
+  includeSecondResponse?: boolean;
 }) {
+  const responses = [
+    {
+      id: 101,
+      indicator_id: 1,
+      indicator: {
+        id: 1,
+        name: "Test Indicator",
+        indicator_code: "2.1.1",
+        governance_area: { id: 2, name: "Disaster Preparedness" },
+      },
+      movs: [{ id: 1, uploaded_at: "2024-01-01T00:00:00Z" }],
+      response_data: overrides?.responseData ?? {},
+      feedback_comments: overrides?.feedbackComments ?? [],
+      flagged_mov_file_ids: [],
+      requires_rework: overrides?.requiresRework ?? false,
+    },
+  ];
+
+  if (overrides?.includeSecondResponse) {
+    responses.push({
+      id: 102,
+      indicator_id: 2,
+      indicator: {
+        id: 2,
+        name: "Second Test Indicator",
+        indicator_code: "2.1.2",
+        governance_area: { id: 2, name: "Disaster Preparedness" },
+      },
+      movs: [{ id: 2, uploaded_at: "2024-01-01T00:00:00Z" }],
+      response_data: {},
+      feedback_comments: [],
+      flagged_mov_file_ids: [],
+      requires_rework: false,
+    });
+  }
+
   return {
     success: true,
     assessment_id: 1,
@@ -210,23 +253,7 @@ function makeAssessment(overrides?: {
         email: "test@example.com",
         barangay: { id: 1, name: "Test Barangay" },
       },
-      responses: [
-        {
-          id: 101,
-          indicator_id: 1,
-          indicator: {
-            id: 1,
-            name: "Test Indicator",
-            indicator_code: "2.1.1",
-            governance_area: { id: 2, name: "Disaster Preparedness" },
-          },
-          movs: [{ id: 1, uploaded_at: "2024-01-01T00:00:00Z" }],
-          response_data: overrides?.responseData ?? {},
-          feedback_comments: overrides?.feedbackComments ?? [],
-          flagged_mov_file_ids: [],
-          requires_rework: overrides?.requiresRework ?? false,
-        },
-      ],
+      responses,
     },
   };
 }
@@ -568,6 +595,61 @@ describe("AssessorValidationClient autosave", () => {
       data: {
         public_comment: null,
         response_data: { assessor_val_item_2: true },
+      },
+    });
+  });
+
+  it("keeps the global dirty status when one dirty assessor response is reverted but another remains dirty", async () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment({ includeSecondResponse: true }),
+      isLoading: false,
+      isError: false,
+      error: null,
+      dataUpdatedAt: Date.now(),
+    });
+
+    render(wrap(<AssessorValidationClient assessmentId={1} />));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit assessor comment once" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit response 102 comment" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Revert response 102 comment" })[0]);
+
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+  });
+
+  it("force-saves dirty assessor edits when the autosave status action is clicked", async () => {
+    validateMutateAsync.mockResolvedValue({ success: true });
+
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      dataUpdatedAt: Date.now(),
+    });
+
+    render(wrap(<AssessorValidationClient assessmentId={1} />));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit assessor comment once" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: /save changes now/i }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(validateMutateAsync).toHaveBeenCalledWith({
+      responseId: 101,
+      data: {
+        public_comment: "first draft",
+        response_data: undefined,
       },
     });
   });

--- a/apps/web/src/components/features/assessor/validation/__tests__/AssessorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/assessor/validation/__tests__/AssessorValidationClient.autosave.test.tsx
@@ -653,4 +653,27 @@ describe("AssessorValidationClient autosave", () => {
       },
     });
   });
+
+  it("blocks browser unload while assessor edits are pending", async () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      dataUpdatedAt: Date.now(),
+    });
+
+    render(wrap(<AssessorValidationClient assessmentId={1} />));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit assessor comment once" })[0]);
+
+    const event = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
 });

--- a/apps/web/src/components/features/shared/AutosaveStatusPill.tsx
+++ b/apps/web/src/components/features/shared/AutosaveStatusPill.tsx
@@ -79,10 +79,14 @@ export function AutosaveStatusPill({
   onRetry,
   className,
 }: AutosaveStatusPillProps) {
-  const [isExpanded, setIsExpanded] = useState(state === "error");
+  const [isExpanded, setIsExpanded] = useState(state === "error" || state === "dirty");
   const config = STATUS_CONFIG[state];
   const Icon = config.icon;
   const useIconOnly = completedSaveCount >= 3 && state !== "error";
+  const canForceSave = state === "dirty" && Boolean(onRetry);
+  const canRetry = state === "error" && Boolean(onRetry);
+  const isActionable = canForceSave || canRetry;
+  const actionLabel = canRetry ? "Retry save" : "Save changes now";
 
   useEffect(() => {
     let animationFrameId: number | null = null;
@@ -173,10 +177,12 @@ export function AutosaveStatusPill({
             <span className="text-sm font-medium">{config.label}</span>
           </div>
 
-          {isExpanded ? (
+          {isExpanded || isActionable ? (
             <div className="flex items-center gap-3 border-l border-current/10 pl-3">
-              <span className="hidden text-xs text-current/80 sm:inline">{config.detail}</span>
-              {state === "error" && onRetry ? (
+              {isExpanded ? (
+                <span className="hidden text-xs text-current/80 sm:inline">{config.detail}</span>
+              ) : null}
+              {isActionable ? (
                 <Button
                   type="button"
                   size="sm"
@@ -186,10 +192,10 @@ export function AutosaveStatusPill({
                     "h-8 rounded-full border-current/20 bg-background/80 px-3 text-xs text-current shadow-none",
                     "hover:bg-background focus-visible:ring-2"
                   )}
-                  aria-label="Retry save"
+                  aria-label={actionLabel}
                 >
                   <RotateCcw className="h-3.5 w-3.5" />
-                  Retry
+                  {canRetry ? "Retry" : "Save now"}
                 </Button>
               ) : null}
             </div>

--- a/apps/web/src/components/features/shared/AutosaveStatusPill.tsx
+++ b/apps/web/src/components/features/shared/AutosaveStatusPill.tsx
@@ -82,7 +82,7 @@ export function AutosaveStatusPill({
   const [isExpanded, setIsExpanded] = useState(state === "error" || state === "dirty");
   const config = STATUS_CONFIG[state];
   const Icon = config.icon;
-  const useIconOnly = completedSaveCount >= 3 && state !== "error";
+  const useIconOnly = completedSaveCount >= 3 && state !== "error" && state !== "dirty";
   const canForceSave = state === "dirty" && Boolean(onRetry);
   const canRetry = state === "error" && Boolean(onRetry);
   const isActionable = canForceSave || canRetry;

--- a/apps/web/src/components/features/shared/__tests__/AutosaveStatusPill.test.tsx
+++ b/apps/web/src/components/features/shared/__tests__/AutosaveStatusPill.test.tsx
@@ -19,6 +19,22 @@ describe("AutosaveStatusPill", () => {
     expect(screen.queryByRole("button", { name: /retry save/i })).not.toBeInTheDocument();
   });
 
+  it("calls onRetry when the dirty status action is clicked", () => {
+    const onRetry = vi.fn();
+
+    render(<AutosaveStatusPill state="dirty" onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes now/i }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not offer manual save while already saving", () => {
+    render(<AutosaveStatusPill state="saving" onRetry={vi.fn()} />);
+
+    expect(screen.queryByRole("button", { name: /save changes now/i })).not.toBeInTheDocument();
+  });
+
   it("shows an inline retry action when autosave fails", () => {
     const onRetry = vi.fn();
 

--- a/apps/web/src/components/features/shared/__tests__/AutosaveStatusPill.test.tsx
+++ b/apps/web/src/components/features/shared/__tests__/AutosaveStatusPill.test.tsx
@@ -35,6 +35,16 @@ describe("AutosaveStatusPill", () => {
     expect(screen.queryByRole("button", { name: /save changes now/i })).not.toBeInTheDocument();
   });
 
+  it("keeps the manual save action visible for dirty state after repeated autosaves", () => {
+    const onRetry = vi.fn();
+
+    render(<AutosaveStatusPill state="dirty" completedSaveCount={3} onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes now/i }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
   it("shows an inline retry action when autosave fails", () => {
     const onRetry = vi.fn();
 

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -336,6 +336,40 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     responsesRef.current = responses;
   }, [responses]);
 
+  const isMeaningfulChecklistValue = (value: unknown): boolean => {
+    if (value === true) return true;
+    if (typeof value === "string") return value.trim().length > 0;
+    return false;
+  };
+
+  const buildValidatorResponseDataSnapshot = (responseId: number): Record<string, any> => {
+    const response = responsesRef.current.find((item) => item.id === responseId);
+    if (!response) return {};
+
+    const snapshotData: Record<string, any> = {};
+    const previousResponseData = (response as AnyRecord).response_data || {};
+
+    Object.keys(checklistStateRef.current).forEach((key) => {
+      if (!key.startsWith(`checklist_${responseId}_`)) return;
+
+      const fieldName = key.replace(`checklist_${responseId}_`, "");
+      const snapshotKey = `validator_val_${fieldName}`;
+      const currentValue = checklistStateRef.current[key];
+      const previousValue = previousResponseData[snapshotKey];
+
+      if (isMeaningfulChecklistValue(currentValue)) {
+        snapshotData[snapshotKey] = currentValue;
+        return;
+      }
+
+      if (previousValue !== undefined && previousValue !== currentValue) {
+        snapshotData[snapshotKey] = currentValue;
+      }
+    });
+
+    return snapshotData;
+  };
+
   const getProgressForResponse = (response: AnyRecord) => {
     const wasCalibrated = Boolean(calibrationRequestedAt) && response.validation_status === null;
     return getValidatorIndicatorProgress(response, {
@@ -398,13 +432,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
 
   const getResponseSnapshot = (responseId: number): string => {
     const formData = formRef.current[responseId];
-    const responseChecklistData: Record<string, any> = {};
-
-    Object.keys(checklistStateRef.current).forEach((key) => {
-      if (!key.startsWith(`checklist_${responseId}_`)) return;
-      const fieldName = key.replace(`checklist_${responseId}_`, "");
-      responseChecklistData[`validator_val_${fieldName}`] = checklistStateRef.current[key];
-    });
+    const responseChecklistData = buildValidatorResponseDataSnapshot(responseId);
 
     const sortedKeys = Object.keys(responseChecklistData).sort();
     const sortedChecklistData: Record<string, any> = {};
@@ -442,6 +470,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     const snapshotData: Record<string, any> = {};
     Object.keys(responseData).forEach((key) => {
       if (!key.startsWith("validator_val_")) return;
+      if (!isMeaningfulChecklistValue(responseData[key])) return;
       snapshotData[key] = responseData[key];
     });
 
@@ -761,6 +790,24 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   }, [dirtyResponseIds, form, checklistState, calibrationFlags]);
 
   useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      const hasPendingChanges =
+        dirtyResponseIdsRef.current.length > 0 ||
+        activeSavePromiseRef.current !== null ||
+        autoSaveTimerRef.current !== null;
+      if (!hasPendingChanges) return;
+
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+
+  useEffect(() => {
     const handleDocumentNavigation = (event: MouseEvent) => {
       if (isInterceptingNavigationRef.current) return;
 
@@ -800,6 +847,9 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
         const saved = await flushPendingChanges({ quiet: true });
         if (saved) {
           router.push(`${url.pathname}${url.search}${url.hash}`);
+          window.setTimeout(() => {
+            isInterceptingNavigationRef.current = false;
+          }, 0);
         } else {
           isInterceptingNavigationRef.current = false;
         }

--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -140,6 +140,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   const lastSavedSnapshotRef = useRef<Record<number, string>>({});
   const isSavingRef = useRef(false);
   const activeSavePromiseRef = useRef<Promise<boolean> | null>(null);
+  const isInterceptingNavigationRef = useRef(false);
   const formRef = useRef(form);
   const checklistStateRef = useRef(checklistState);
   const calibrationFlagsRef = useRef(calibrationFlags);
@@ -341,6 +342,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
       checklistState,
       localMovAttentionByFileId: movAttentionByResponse[response.id] ?? {},
       strictChecklistRequired: wasCalibrated,
+      localForm: form[response.id],
     });
   };
 
@@ -563,9 +565,9 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
         next = alreadyDirty ? prev : [...prev, responseId];
       }
       dirtyResponseIdsRef.current = next;
+      setDraftSaveState(next.length > 0 ? "dirty" : "saved");
       return next;
     });
-    setDraftSaveState(nextSnapshot === savedSnapshot ? "saved" : "dirty");
   };
 
   const saveResponses = async (
@@ -591,6 +593,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
       if (remainingResponseIds.length === 0) {
         if (!options.quiet && dirtyResponseIdsRef.current.length === 0) {
           setDraftSaveState("saved");
+          toast.success("Assessment progress saved", { duration: 2500 });
         }
         return true;
       }
@@ -756,6 +759,58 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
       }
     };
   }, [dirtyResponseIds, form, checklistState, calibrationFlags]);
+
+  useEffect(() => {
+    const handleDocumentNavigation = (event: MouseEvent) => {
+      if (isInterceptingNavigationRef.current) return;
+
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest("a[href]") as HTMLAnchorElement | null;
+      if (!anchor) return;
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      if (anchor.target && anchor.target !== "_self") return;
+      if (anchor.hasAttribute("download")) return;
+
+      const href = anchor.getAttribute("href");
+      if (!href || href.startsWith("#")) return;
+
+      const url = new URL(anchor.href, window.location.href);
+      if (url.origin !== window.location.origin) return;
+      if (url.href === window.location.href) return;
+
+      const hasPendingChanges =
+        dirtyResponseIdsRef.current.length > 0 ||
+        activeSavePromiseRef.current !== null ||
+        autoSaveTimerRef.current !== null;
+      if (!hasPendingChanges) return;
+
+      event.preventDefault();
+      isInterceptingNavigationRef.current = true;
+
+      void (async () => {
+        const saved = await flushPendingChanges({ quiet: true });
+        if (saved) {
+          router.push(`${url.pathname}${url.search}${url.hash}`);
+        } else {
+          isInterceptingNavigationRef.current = false;
+        }
+      })();
+    };
+
+    document.addEventListener("click", handleDocumentNavigation, true);
+    return () => {
+      document.removeEventListener("click", handleDocumentNavigation, true);
+    };
+  }, [router]);
 
   const onFinalize = async () => {
     // Prevent double-clicking by checking if already in progress

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -13,6 +13,7 @@ import { ValidatorValidationClient } from "../ValidatorValidationClient";
 const routerPush = vi.fn();
 const validateMutateAsync = vi.fn();
 const finalizeMutateAsync = vi.fn();
+const calibrateMutateAsync = vi.fn();
 
 vi.mock("@sinag/shared", () => ({
   getGetAssessorAssessmentsAssessmentIdQueryKey: (id: number) => ["assessor", "assessments", id],
@@ -26,7 +27,7 @@ vi.mock("@sinag/shared", () => ({
     isPending: false,
   })),
   usePostAssessorAssessmentsAssessmentIdCalibrate: () => ({
-    mutateAsync: vi.fn(),
+    mutateAsync: calibrateMutateAsync,
     isPending: false,
   }),
   useGetAssessorMovsMovFileIdAnnotations: () => ({
@@ -70,6 +71,12 @@ vi.mock("next/dynamic", () => ({
           <button onClick={() => props.setField(201, "publicComment", "validator latest draft")}>
             Edit validator comment twice
           </button>
+          <button onClick={() => props.setField(202, "publicComment", "response 202 draft")}>
+            Edit response 202 comment
+          </button>
+          <button onClick={() => props.setField(202, "publicComment", "")}>
+            Revert response 202 comment
+          </button>
           <button onClick={() => props.onChecklistChange?.("checklist_201_requirement_1", true)}>
             Toggle validator checklist
           </button>
@@ -78,6 +85,9 @@ vi.mock("next/dynamic", () => ({
           </button>
           <button onClick={() => props.onChecklistChange?.("checklist_201_requirement_2", true)}>
             Toggle validator checklist 2
+          </button>
+          <button onClick={() => props.onCalibrationFlagChange?.(201, true)}>
+            Flag validator calibration
           </button>
         </div>
       );
@@ -170,8 +180,50 @@ function expectSidebarAttention(responseId: number, hasAttention: boolean) {
 
 function makeAssessment(
   responseOverrides: Record<string, any> = {},
-  assessmentOverrides: Record<string, any> = {}
+  assessmentOverrides: Record<string, any> = {},
+  options: { includeSecondResponse?: boolean } = {}
 ) {
+  const responses = [
+    {
+      id: 201,
+      indicator_id: 1,
+      indicator: {
+        id: 1,
+        name: "Test Indicator",
+        indicator_code: "2.1.1",
+        governance_area: { id: 2, name: "Disaster Preparedness" },
+        checklist_items: [{ item_id: "requirement_1", item_type: "checkbox", required: true }],
+        validation_rule: "ALL_ITEMS_REQUIRED",
+      },
+      movs: [{ id: 1, uploaded_at: "2024-01-01T00:00:00Z" }],
+      response_data: {},
+      feedback_comments: [],
+      validation_status: "PASS",
+      flagged_for_calibration: false,
+      ...responseOverrides,
+    },
+  ];
+
+  if (options.includeSecondResponse) {
+    responses.push({
+      id: 202,
+      indicator_id: 2,
+      indicator: {
+        id: 2,
+        name: "Second Test Indicator",
+        indicator_code: "2.1.2",
+        governance_area: { id: 2, name: "Disaster Preparedness" },
+        checklist_items: [{ item_id: "requirement_1", item_type: "checkbox", required: true }],
+        validation_rule: "ALL_ITEMS_REQUIRED",
+      },
+      movs: [{ id: 2, uploaded_at: "2024-01-01T00:00:00Z" }],
+      response_data: {},
+      feedback_comments: [],
+      validation_status: "PASS",
+      flagged_for_calibration: false,
+    });
+  }
+
   return {
     success: true,
     assessment_id: 1,
@@ -186,26 +238,7 @@ function makeAssessment(
       },
       calibrated_area_ids: [],
       ...assessmentOverrides,
-      responses: [
-        {
-          id: 201,
-          indicator_id: 1,
-          indicator: {
-            id: 1,
-            name: "Test Indicator",
-            indicator_code: "2.1.1",
-            governance_area: { id: 2, name: "Disaster Preparedness" },
-            checklist_items: [{ item_id: "requirement_1", item_type: "checkbox", required: true }],
-            validation_rule: "ALL_ITEMS_REQUIRED",
-          },
-          movs: [{ id: 1, uploaded_at: "2024-01-01T00:00:00Z" }],
-          response_data: {},
-          feedback_comments: [],
-          validation_status: "PASS",
-          flagged_for_calibration: false,
-          ...responseOverrides,
-        },
-      ],
+      responses,
     },
   };
 }
@@ -223,6 +256,7 @@ describe("ValidatorValidationClient autosave", () => {
       isPending: false,
     });
     finalizeMutateAsync.mockResolvedValue({ new_status: "AWAITING_MLGOO_APPROVAL" });
+    calibrateMutateAsync.mockResolvedValue({ calibrated_indicators_count: 1 });
   });
 
   afterEach(() => {
@@ -373,6 +407,98 @@ describe("ValidatorValidationClient autosave", () => {
         flagged_for_calibration: false,
       },
     });
+  });
+
+  it("keeps the global dirty status when one dirty validator response is reverted but another remains dirty", async () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment({}, {}, { includeSecondResponse: true }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit validator comment once" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit response 202 comment" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Revert response 202 comment" })[0]);
+
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+  });
+
+  it("force-saves dirty validator edits when the autosave status action is clicked", async () => {
+    validateMutateAsync.mockResolvedValue({ success: true });
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit validator comment once" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: /save changes now/i }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(validateMutateAsync).toHaveBeenCalledWith({
+      responseId: 201,
+      data: {
+        validation_status: "PASS",
+        public_comment: "validator first draft",
+        response_data: undefined,
+        flagged_for_calibration: false,
+      },
+    });
+  });
+
+  it("flushes pending validator edits before internal navigation", async () => {
+    validateMutateAsync.mockResolvedValue({ success: true });
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit validator comment once" })[0]);
+    fireEvent.click(screen.getByRole("link", { name: /queue/i }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(validateMutateAsync).toHaveBeenCalled();
+    expect(routerPush).toHaveBeenCalledWith("/validator/submissions");
+  });
+
+  it("submits for calibration after pending validator edits are saved", async () => {
+    validateMutateAsync.mockResolvedValue({ success: true });
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit validator comment once" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Flag validator calibration" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: /submit for calibration/i }));
+    fireEvent.click(screen.getByRole("button", { name: /yes, submit for calibration/i }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(validateMutateAsync).toHaveBeenCalled();
+    expect(calibrateMutateAsync).toHaveBeenCalledWith({ assessmentId: 1 });
   });
 
   it("patches the cached assessment and invalidates queries after a successful validator autosave", async () => {

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -403,7 +403,80 @@ describe("ValidatorValidationClient autosave", () => {
       data: {
         validation_status: "PASS",
         public_comment: null,
-        response_data: { validator_val_requirement_1: false, validator_val_requirement_2: true },
+        response_data: { validator_val_requirement_2: true },
+        flagged_for_calibration: false,
+      },
+    });
+  });
+
+  it("does not include a cleared validator checklist item in later saves after server hydration removes it", async () => {
+    validateMutateAsync.mockResolvedValue({ success: true });
+    let assessmentData = makeAssessment({
+      response_data: { validator_val_requirement_1: true },
+    });
+
+    mockUseGetAssessorAssessmentsAssessmentId.mockImplementation(() => ({
+      data: assessmentData,
+      isLoading: false,
+      isError: false,
+      error: null,
+      dataUpdatedAt: Date.now(),
+    }));
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <ValidatorValidationClient assessmentId={1} />
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Set validator checklist false" })[0]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+      await Promise.resolve();
+    });
+
+    expect(validateMutateAsync).toHaveBeenCalledTimes(1);
+    expect(validateMutateAsync).toHaveBeenLastCalledWith({
+      responseId: 201,
+      data: {
+        validation_status: "PASS",
+        public_comment: null,
+        response_data: { validator_val_requirement_1: false },
+        flagged_for_calibration: false,
+      },
+    });
+
+    assessmentData = makeAssessment({
+      response_data: {},
+    });
+
+    rerender(
+      <QueryClientProvider client={client}>
+        <ValidatorValidationClient assessmentId={1} />
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit validator comment once" })[0]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+      await Promise.resolve();
+    });
+
+    expect(validateMutateAsync).toHaveBeenCalledTimes(2);
+    expect(validateMutateAsync).toHaveBeenLastCalledWith({
+      responseId: 201,
+      data: {
+        validation_status: "PASS",
+        public_comment: "validator first draft",
+        response_data: undefined,
         flagged_for_calibration: false,
       },
     });
@@ -475,6 +548,25 @@ describe("ValidatorValidationClient autosave", () => {
 
     expect(validateMutateAsync).toHaveBeenCalled();
     expect(routerPush).toHaveBeenCalledWith("/validator/submissions");
+  });
+
+  it("blocks browser unload while validator edits are pending", () => {
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+      dataUpdatedAt: Date.now(),
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit validator comment once" })[0]);
+
+    const event = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it("submits for calibration after pending validator edits are saved", async () => {

--- a/apps/web/src/components/features/validator/__tests__/validator-progress.test.ts
+++ b/apps/web/src/components/features/validator/__tests__/validator-progress.test.ts
@@ -248,4 +248,15 @@ describe("validator-progress", () => {
       })
     ).toEqual({ status: "completed", hasMovNotes: false });
   });
+
+  it("uses local validator form status before stale server validation status", () => {
+    expect(
+      getValidatorIndicatorProgress(response({ validation_status: null }), {
+        checklistState: {},
+        localMovAttentionByFileId: {},
+        strictChecklistRequired: false,
+        localForm: { status: "Pass", publicComment: "" },
+      }).status
+    ).toBe("completed");
+  });
 });

--- a/apps/web/src/components/features/validator/validator-progress.ts
+++ b/apps/web/src/components/features/validator/validator-progress.ts
@@ -4,6 +4,7 @@ export interface ValidatorProgressInput {
   checklistState: Record<string, any>;
   localMovAttentionByFileId: Record<number, boolean | undefined>;
   strictChecklistRequired: boolean;
+  localForm?: { status?: "Pass" | "Fail" | "Conditional"; publicComment?: string };
 }
 
 export interface ValidatorChecklistCompletion {
@@ -156,6 +157,14 @@ export function hasExistingValidationStatus(response: AnyRecord): boolean {
   return ["PASS", "FAIL", "CONDITIONAL"].includes(String(status).toUpperCase());
 }
 
+function hasLocalValidationStatus(localForm?: ValidatorProgressInput["localForm"]): boolean {
+  return (
+    localForm?.status === "Pass" ||
+    localForm?.status === "Fail" ||
+    localForm?.status === "Conditional"
+  );
+}
+
 export function hasActiveValidatorMovAttention(
   response: AnyRecord,
   options: { localMovAttentionByFileId: Record<number, boolean | undefined> }
@@ -182,10 +191,12 @@ export function getValidatorIndicatorProgress(
     localMovAttentionByFileId: input.localMovAttentionByFileId,
   });
   const checklistCompletion = getValidatorChecklistCompletion(response, input.checklistState);
+  const hasValidationStatus =
+    hasLocalValidationStatus(input.localForm) || hasExistingValidationStatus(response);
 
   const reviewed = input.strictChecklistRequired
     ? checklistCompletion.isComplete && !hasMovNotes
-    : checklistCompletion.isComplete || hasMovNotes || hasExistingValidationStatus(response);
+    : checklistCompletion.isComplete || hasMovNotes || hasValidationStatus;
 
   return {
     status: reviewed ? "completed" : "not_started",


### PR DESCRIPTION
## Summary
- Keep the autosave force-save action visible whenever validation edits are dirty.
- Preserve rapid assessor and validator edits by serializing saves, re-saving changes made during in-flight saves, and flushing before validation workflow/navigation actions.
- Align validator checklist clear behavior with assessor snapshots and add unload protection for pending validation edits.

## Test Plan
- [x] cd apps/web && pnpm exec vitest run src/components/features/shared/__tests__/AutosaveStatusPill.test.tsx src/components/features/assessor/validation/__tests__/AssessorValidationClient.autosave.test.tsx src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx src/components/features/validator/__tests__/validator-progress.test.ts

## Notes
- Docs and Markdown planning files were intentionally left out of this PR.