### PR TITLE
fix(web): prevent stale validator compliance redirects

### DIFF
--- a/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
+++ b/apps/web/src/components/features/validator/ValidatorValidationClient.tsx
@@ -149,6 +149,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
   const isSavingRef = useRef(false);
   const activeSavePromiseRef = useRef<Promise<boolean> | null>(null);
   const isInterceptingNavigationRef = useRef(false);
+  const navigationIntentRef = useRef(0);
   const formRef = useRef(form);
   const checklistStateRef = useRef(checklistState);
   const calibrationFlagsRef = useRef(calibrationFlags);
@@ -743,6 +744,11 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
     await flushPendingChanges();
   };
 
+  const claimNavigationIntent = () => {
+    navigationIntentRef.current += 1;
+    return navigationIntentRef.current;
+  };
+
   useEffect(() => {
     if (!isOpeningComplianceOverview) {
       setComplianceOverviewLoadingStep(0);
@@ -866,17 +872,17 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
 
       event.preventDefault();
       isInterceptingNavigationRef.current = true;
+      const navigationIntent = claimNavigationIntent();
 
       void (async () => {
         const saved = await flushPendingChanges({ quiet: true });
-        if (saved) {
+        if (saved && navigationIntentRef.current === navigationIntent) {
           router.push(`${url.pathname}${url.search}${url.hash}`);
-          window.setTimeout(() => {
-            isInterceptingNavigationRef.current = false;
-          }, 0);
-        } else {
-          isInterceptingNavigationRef.current = false;
         }
+
+        window.setTimeout(() => {
+          isInterceptingNavigationRef.current = false;
+        }, 0);
       })();
     };
 
@@ -1216,7 +1222,7 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
               variant="default"
               size="sm"
               className="gap-1 sm:gap-1.5 bg-blue-600 hover:bg-blue-700 text-white text-xs sm:text-sm px-2 sm:px-4"
-              disabled={draftSaveState === "saving" || isOpeningComplianceOverview}
+              disabled={isOpeningComplianceOverview}
               aria-busy={isOpeningComplianceOverview}
               aria-label={
                 isOpeningComplianceOverview
@@ -1227,13 +1233,16 @@ export function ValidatorValidationClient({ assessmentId }: ValidatorValidationC
                 if (isOpeningComplianceOverview) return;
 
                 // Save draft first, then navigate to compliance overview
+                const navigationIntent = claimNavigationIntent();
                 setIsOpeningComplianceOverview(true);
                 const saved = await flushPendingChanges({ quiet: true });
                 if (!saved) {
                   setIsOpeningComplianceOverview(false);
                   return;
                 }
-                router.push(`/validator/submissions/${assessmentId}/compliance`);
+                if (navigationIntentRef.current === navigationIntent) {
+                  router.push(`/validator/submissions/${assessmentId}/compliance`);
+                }
               }}
             >
               {isOpeningComplianceOverview ? (

--- a/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
+++ b/apps/web/src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx
@@ -439,6 +439,41 @@ describe("ValidatorValidationClient autosave", () => {
     expect(routerPush).toHaveBeenCalledTimes(1);
   });
 
+  it("cancels a stale pending queue navigation when opening compliance overview", async () => {
+    const activeSave = deferred<unknown>();
+    validateMutateAsync.mockImplementationOnce(() => activeSave.promise);
+    mockUseGetAssessorAssessmentsAssessmentId.mockReturnValue({
+      data: makeAssessment(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(wrap(<ValidatorValidationClient assessmentId={1} />));
+
+    // Make the page dirty so link navigation is intercepted and waits for the save.
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit validator comment once" })[0]);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("link", { name: /queue/i }));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /compliance overview/i }));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      activeSave.resolve({ success: true });
+      await activeSave.promise;
+      await Promise.resolve();
+    });
+
+    expect(routerPush).toHaveBeenCalledTimes(1);
+    expect(routerPush).toHaveBeenCalledWith("/validator/submissions/1/compliance");
+  });
+
   it("waits for an active auto-save before finalizing", async () => {
     const firstSave = deferred<unknown>();
 


### PR DESCRIPTION
## Summary
- Prevent stale pending validator queue navigation from winning after a later Compliance Overview action.
- Allow Compliance Overview to claim the latest navigation intent while waiting for an in-flight autosave.
- Add regression coverage for the queue-to-compliance navigation race.

## Test Plan
- pnpm --filter web test src/components/features/validator/__tests__/ValidatorValidationClient.autosave.test.tsx

## Notes
- Left existing untracked .codex and docs/superpowers/plans/2026-04-07-validator-queue-phase-gating.md untouched.